### PR TITLE
Working Drug Exposure SQL and Tests added with defaults. All tests PASS.

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_drug_exposure.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_drug_exposure.sql
@@ -1,0 +1,170 @@
+# DESCRIPTION:
+# Creates a row in cdm-drug exposure table for each FinnGen id in the PURCH registry.
+# Person id is extracted from person table
+#
+# PARAMETERS:
+#
+# - schema_etl_input: schema with the etl input tables
+# - schema_cdm_output: schema with the output CDM tables
+
+
+TRUNCATE TABLE @schema_cdm_output.drug_exposure;
+INSERT INTO @schema_cdm_output.drug_exposure
+(
+  drug_exposure_id,
+  person_id,
+  drug_concept_id,
+  drug_exposure_start_date,
+  drug_exposure_start_datetime,
+  drug_exposure_end_date,
+  drug_exposure_end_datetime,
+  verbatim_end_date,
+  drug_type_concept_id,
+  stop_reason,
+  refills,
+  quantity,
+  days_supply,
+  sig,
+  route_concept_id,
+  lot_number,
+  provider_id,
+  visit_occurrence_id,
+  visit_detail_id,
+  drug_source_value,
+  drug_source_concept_id,
+  route_source_value,
+  dose_unit_source_value
+)
+
+WITH
+# 1 - Get all purchase events form the PURCH registry
+purchases_from_registers AS (
+  SELECT *
+  FROM(
+    SELECT FINNGENID,
+           SOURCE,
+           APPROX_EVENT_DAY,
+           CODE1_ATC_CODE AS CODE1,
+           CODE3_VNRO AS CODE3,
+           CODE4_PLKM AS CODE4,
+           INDEX
+    FROM @schema_etl_input.purch
+    #WHERE FINNGENID = 'FG00000020'
+  )
+),
+# 2 - Add vnr omop concept id
+purchases_from_registers_vnr_info AS (
+  SELECT pg.*,
+         fgc.omop_concept_id AS drug_omop_concept_id,
+         fgc.name_en AS medicine_name
+  FROM purchases_from_registers AS pg
+  LEFT JOIN @schema_table_codes_info AS fgc
+  ON fgc.FG_CODE1 IS NOT DISTINCT FROM LPAD(pg.CODE3,6,'0') AND
+     fgc.vocabulary_id = 'VNRfi'
+),
+# 3 - Add standard concept id and take the top priority
+purchases_from_registers_vnr_info_standard_concept_id AS (
+  SELECT prvi.*,
+         drugmap.concept_id_2,
+         RANK() OVER (PARTITION BY prvi.CODE3
+                            ORDER BY CASE drugmap.concept_class_id
+                                          WHEN 'Branded Pack' THEN 1
+                                          WHEN 'Clinical Pack' THEN 2
+                                          WHEN 'Branded Drug' THEN 3
+                                          WHEN 'Clinical Drug' THEN 4
+                                          WHEN 'Branded Drug Comp' THEN 5
+                                          WHEN 'Clinical Drug Comp' THEN 6
+                                          WHEN 'Branded Drug Form' THEN 7
+                                          WHEN 'Clinical Drug Form' THEN 8
+                                          WHEN 'Ingredient' THEN 9
+                                          #WHEN 'Quant Clinical Drug' THEN 9
+                                          #WHEN 'Quantified Branded Drug' THEN 10
+                                          #WHEN 'Clinical Drug Box' THEN 11
+                                          #WHEN 'Quantified Clinical Box' THEN 12
+                                          #ELSE 13
+                                          ELSE 10
+                                     END
+                           ) AS drug_priority
+  FROM purchases_from_registers_vnr_info AS prvi
+  LEFT JOIN (
+    SELECT cr.concept_id_1,
+           cr.concept_id_2,
+           c.concept_class_id,
+           c.concept_name
+    FROM @schema_vocab.concept_relationship AS cr
+    JOIN @schema_vocab.concept AS c
+    ON cr.concept_id_2 = c.concept_id
+    WHERE cr.relationship_id = 'Maps to' AND c.domain_id IN ('Drug')
+  ) AS drugmap
+  ON CAST(prvi.drug_omop_concept_id AS INT64) = drugmap.concept_id_1
+)
+
+# 4 - Shape into drug exposure table
+SELECT
+# drug_exposure_id
+ROW_NUMBER() OVER(ORDER by prvisci.SOURCE, prvisci.INDEX) AS drug_exposure_id,
+# person_id
+p.person_id AS person_id,
+# drug_concept_id
+CASE
+    WHEN prvisci.concept_id_2 IS NOT NULL THEN prvisci.concept_id_2
+		ELSE 0
+END AS drug_concept_id,
+# drug_exposure_start_date
+prvisci.APPROX_EVENT_DAY AS drug_exposure_start_date,
+# drug_exposure_start_datetime
+DATETIME(TIMESTAMP(prvisci.APPROX_EVENT_DAY)) AS drug_exposure_start_datetime,
+# drug_exposure_end_date
+prvisci.APPROX_EVENT_DAY AS drug_exposure_end_date,
+# drug_exposure_end_datetime
+DATETIME(TIMESTAMP(prvisci.APPROX_EVENT_DAY)) AS drug_exposure_end_datetime,
+# verbatim_end_date
+CAST(NULL AS DATE) AS verbatim_end_date,
+# drug_type_concept_id
+32879 AS drug_type_concept_id,
+# stop_reason
+CAST(NULL AS STRING) AS stop_reason,
+# refills
+NULL AS refills,
+# quantity
+CASE
+    WHEN prvisci.CODE4 IS NOT NULL THEN CAST(prvisci.CODE4 AS FLOAT64)
+    ELSE 0
+END AS quantity,
+# days_supply
+1 AS days_supply,
+# sig
+prvisci.medicine_name AS sig,
+# route_concept_id
+NULL AS route_concept_id,
+# lot_number
+CAST(NULL AS STRING) AS lot_number,
+# provider_id
+vo.provider_id AS provider_id,
+# visit_occurrence_id
+vo.visit_occurrence_id AS visit_occurrence_id,
+# visit_detail_id
+0 AS visit_detail_id,
+# drug_source_value
+CASE
+    WHEN CAST(prvisci.CODE3 AS INT64) > 0 THEN LPAD(prvisci.CODE3,6,'0')
+    ELSE prvisci.CODE3
+END AS drug_source_value,
+# drug_source_concept_id
+CASE
+    WHEN prvisci.drug_omop_concept_id IS NOT NULL THEN CAST(prvisci.drug_omop_concept_id AS INT64)
+    ELSE 0
+END AS drug_source_concept_id,
+# route_source_value
+CAST(NULL AS STRING) AS route_source_value,
+# dose_unit_source_value
+CAST(NULL AS STRING) AS dose_unit_source_value
+FROM purchases_from_registers_vnr_info_standard_concept_id AS prvisci
+JOIN @schema_cdm_output.person AS p
+ON p.person_source_value = prvisci.FINNGENID
+JOIN @schema_cdm_output.visit_occurrence AS vo
+ON vo.person_id = p.person_id AND
+   CONCAT('SOURCE=',prvisci.SOURCE,';INDEX=',prvisci.INDEX) = vo.visit_source_value AND
+   prvisci.APPROX_EVENT_DAY = vo.visit_start_date
+WHERE prvisci.drug_priority = 1
+ORDER BY p.person_id, prvisci.APPROX_EVENT_DAY;

--- a/3_etl_code/ETL_Orchestration/tests/unittest_etl_drug_exposure_table.R
+++ b/3_etl_code/ETL_Orchestration/tests/unittest_etl_drug_exposure_table.R
@@ -1,0 +1,155 @@
+# DESCRIPTION:
+# Unit tests for etl_drug_exposure.
+#
+# PARAMETERS:
+#
+# Test ids: 04xx
+# Finngenids: FG04xxyyy
+
+# Declare Test - 0401 - default
+declareTest(0401, "etl_drug_expsoure works with defaults")
+
+add_finngenid_info(
+  finngenid="FG0401001"
+)
+add_purch(
+  finngenid = "FG0401001",
+  source = "PURCH",
+  event_age = as_subquery(47.26),
+  approx_event_day = "1994-01-08",
+  code1_atc_code = "S01ED51",
+  code3_vnro = "068220",
+  index = "FG0401001-1"
+)
+expect_drug_exposure(
+  # visit_occurrence_id rand
+  person_id = lookup_person("person_id", person_source_value="FG0401001"),
+  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+                                                person_id = lookup_person("person_id",person_source_value = "FG0401001"),
+                                                visit_source_value = "SOURCE=PURCH;INDEX=FG0401001-1"),
+  drug_concept_id = as_subquery(21021370),
+  drug_exposure_start_date = "1994-01-08",
+  drug_exposure_start_datetime = "1994-01-08T00:00:00",
+  drug_exposure_end_date = "1994-01-08",
+  drug_exposure_end_datetime = "1994-01-08T00:00:00",
+  verbatim_end_date = NULL,
+  drug_type_concept_id = as_subquery(32879),
+  stop_reason = NULL,
+  refills = NULL,
+  quantity = as_subquery(1.0),
+  days_supply = as_subquery(1),
+  sig = "GANFORT eye drops, solution 0,3 mg/ml+5 mg/ml; 3 x 3 ml",
+  route_concept_id = NULL,
+  lot_number = NULL,
+  provider_id = as_subquery(0),
+  visit_detail_id = as_subquery(0),
+  drug_source_concept_id = as_subquery(2030000182),
+  drug_source_value = "068220",
+  route_source_value = NULL,
+  dose_unit_source_value = NULL
+)
+
+# TESTS MAPPING CODES WITH STANDARD MAPPING  -----------------------------------------------------------------------------
+
+# Declare Test - 0402 - Find standard for an example code for source PURCH
+declareTest(0402, "etl_drug_expsoure adds one event for each code with standard mapping for source PURCH")
+
+add_finngenid_info(
+  finngenid="FG0402001"
+)
+add_purch(
+  finngenid = "FG0402001",
+  source = "PURCH",
+  code3_vnro = "169275",
+  index = "FG0402001-1"
+)
+expect_drug_exposure(
+  person_id = lookup_person("person_id", person_source_value="FG0402001"),
+  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+                                                person_id = lookup_person("person_id",person_source_value = "FG0402001"),
+                                                visit_source_value = "SOURCE=PURCH;INDEX=FG0402001-1"),
+  drug_concept_id = as_subquery(19107244),
+  drug_source_value = "169275",
+  drug_source_concept_id = as_subquery(2030001155)
+)
+
+# TESTS MAPPING CODES WITH MULTIPLE STANDARD MAPPING  -----------------------------------------------------------------------------
+
+# Declare Test - 0403 - vnr code that maps to two standard RxNorm codes
+declareTest(0403, "etl_drug_expsoure adds two events for a vnr code with standard mapping to two drug codes")
+
+add_finngenid_info(
+  finngenid="FG0403001"
+)
+add_purch(
+  finngenid = "FG0403001",
+  source = "PURCH",
+  code3_vnro = "493528",
+  index = "FG0403001-1"
+)
+expect_drug_exposure(
+  person_id = lookup_person("person_id", person_source_value="FG0403001"),
+  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+                                                person_id = lookup_person("person_id",person_source_value = "FG0403001"),
+                                                visit_source_value = "SOURCE=PURCH;INDEX=FG0403001-1"),
+  drug_concept_id = as_subquery(904542),
+  drug_source_value = "493528",
+  drug_source_concept_id = as_subquery(2030001521)
+)
+expect_drug_exposure(
+  person_id = lookup_person("person_id", person_source_value="FG0403001"),
+  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+                                                person_id = lookup_person("person_id",person_source_value = "FG0403001"),
+                                                visit_source_value = "SOURCE=PURCH;INDEX=FG0403001-1"),
+  drug_concept_id = as_subquery(904639),
+  drug_source_value = "493528",
+  drug_source_concept_id = as_subquery(2030001521)
+)
+
+# TESTS CODES WITH NON-STANDARD MAPPING BUT WITHOUT STANDARD MAPPING ------------------------------------------------------------
+
+# Declare Test - 0404 - vnr code with non-standard mapping and without standard mapping
+declareTest(0404, "etl_drug_expsoure adds one event for a vnr code with non-standard mapping and without standard mapping")
+
+add_finngenid_info(
+  finngenid="FG0404001"
+)
+add_purch(
+  finngenid = "FG0404001",
+  source = "PURCH",
+  code3_vnro = "000752",
+  index = "FG0404001-1"
+)
+expect_drug_exposure(
+  person_id = lookup_person("person_id", person_source_value="FG0404001"),
+  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+                                                person_id = lookup_person("person_id",person_source_value = "FG0404001"),
+                                                visit_source_value = "SOURCE=PURCH;INDEX=FG0404001-1"),
+  drug_concept_id = as_subquery(0),
+  drug_source_value = "000752",
+  drug_source_concept_id = as_subquery(2030002735)
+)
+
+# TESTS CODES WITHOUT NON-STANDARD MAPPING --------------------------------------------------------------------------------------
+
+# Declare Test - 0405 - vnr code without non-standard and standard mappings
+declareTest(0405, "etl_drug_expsoure adds one event for a vnr code without non-standard and standard mappings")
+
+add_finngenid_info(
+  finngenid="FG0405001"
+)
+add_purch(
+  finngenid = "FG0405001",
+  source = "PURCH",
+  code3_vnro = "-1",
+  index = "FG0405001-1"
+)
+expect_drug_exposure(
+  person_id = lookup_person("person_id", person_source_value="FG0405001"),
+  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+                                                person_id = lookup_person("person_id",person_source_value = "FG0405001"),
+                                                visit_source_value = "SOURCE=PURCH;INDEX=FG0405001-1"),
+  drug_concept_id = as_subquery(0),
+  drug_source_value = "-1",
+  drug_source_concept_id = as_subquery(0)
+)


### PR DESCRIPTION
This is for issue #32 

This is very simple and basic drug exposure table that treats VNR as a diagnose code.
The logic is as follows
1. Get PRUCH events from purch table
2. Add them with omop_concept_id from fg_codes_info
3.  Add them standard_concept_id from cdm_vocabulary and filter based on priority
4. Will end up with one row per drug purch (or more than one if maps to 2 standard concepts)

With the following defaults
drug_exposure_end_date = drug_exposure_start_date
quantity = code4_package_size
rest to defaults