### PR TITLE
39 dockerise for testing in sandbox

### DIFF
--- a/3_etl_code/ETL_Orchestration/Dockerfile
+++ b/3_etl_code/ETL_Orchestration/Dockerfile
@@ -1,47 +1,44 @@
 # Get Rstudio server from Rocker
 FROM rocker/rstudio:4.2.2
 
-MAINTAINER Sam Padmanabhuni <sam.padmanabhuni@helsinki.fi>
+LABEL org.opencontainers.image.authors="sam.padmanabhuni@helsinki.fi"
 
-# create ETL_Orchestration folder
-RUN mkdir /home/rstudio/ETL_Orchestration
+# Copy ETL_Orchestration folder
+RUN mkdir -p /home/rstudio
+WORKDIR /home/rstudio
+COPY --chown=rstudio . .
 
-# Install system dependencies and Java dependecies
+# Install System, Python and Java dependecies
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y wget \
-                       gnupg2 \
-                       build-essential \
-                       libpcre2-dev \
-                       liblzma-dev liblzma5 \
-                       libicu-dev \
-                       libxml2-dev \
-                       libpng-dev \
-                       software-properties-common && \
-    apt-get clean all && \
-    apt-get purge && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get install -y build-essential \
+     gnupg2 \
+     libpcre2-dev \
+     liblzma-dev \
+     liblzma5 \
+     libicu-dev \
+     libxml2-dev \
+     libpng-dev \
+     libncurses5-dev \
+     libgdbm-dev \
+     libnss3-dev \
+     libssl-dev \
+     libreadline-dev \
+     libffi-dev \
+     libsqlite3-dev \
+     libbz2-dev \
+     software-properties-common \
+     wget \
+     xclip \
+     zlib1g-dev && \
+     apt-get clean all && \
+     apt-get purge && \
+     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Add Java 8 repo and install
-#RUN add-apt-repository ppa:openjdk-r/ppa && \
-#    apt-get update && \
-#    apt-get install -y openjdk-8-jdk && \
-#    R CMD javareconf
+# Install default JAVA jre and jdk
 RUN apt-get update -y && \
     apt-get install -y default-jre default-jdk && \
     R CMD javareconf
-
-# Install Python system dependecies
-RUN apt-get install -y zlib1g-dev \
-    libncurses5-dev \
-    libgdbm-dev \
-    libnss3-dev \
-    libssl-dev \
-    libreadline-dev \
-    libffi-dev \
-    libsqlite3-dev \
-    libbz2-dev \
-    zlib1g-dev
 
 # Install Python 3.10.6
 RUN wget https://www.python.org/ftp/python/3.10.6/Python-3.10.6.tgz && \
@@ -56,30 +53,16 @@ RUN wget https://www.python.org/ftp/python/3.10.6/Python-3.10.6.tgz && \
 # Link python
 RUN ln -s /usr/local/bin/python3.10 /usr/local/bin/python
 
+# Set the user rstudio here
+USER rstudio
+
 # Install Python packages
-COPY ETL_Orchestration/requirements.txt /home/rstudio/ETL_Orchestration
-RUN python3.10 -m pip install --upgrade pip && \
-    pip3 install -r /home/rstudio/ETL_Orchestration/requirements.txt
-
-# Everytime run bash will restart to get activated
-SHELL ["bash","-lc"]
-
-# Set workding directory as ETL_Orhcestration
-WORKDIR /home/rstudio/ETL_Orchestration
+RUN python3.10 -m pip install --upgrade pip
 
 # Recreate R evnironment
-COPY ETL_Orchestration/renv.lock renv.lock
-RUN mkdir -p renv
-COPY ETL_Orchestration/.Rprofile .Rprofile
-COPY ETL_Orchestration/renv/activate.R renv/activate.R
-COPY ETL_Orchestration/renv/settings.dcf renv/settings.dcf
+ENV RENV_PATHS_LIBRARY renv/library
 RUN R -e "renv::restore()"
 
-# COPY sql and tests
-COPY ETL_Orchestration/sql sql
-COPY ETL_Orchestration/tests tests
-COPY ETL_Orchestration/R R
-COPY ETL_Orchestration/R_scripts R_scripts
-COPY ETL_Orchestration/config config
-COPY ETL_Orchestration/db_drivers db_drivers
-COPY ETL_Orchestration/README.* .
+# Set it back to root.
+# This step very much is necessary or else the docker image will not run
+USER root


### PR DESCRIPTION
This is for issue number #39 

The docker image is properly built and works. 

I have tested it on atlas-development-270609 unit test and it gave correct results.

The Dockerfile creates an image with following logic
- rstudio server as base for the R version we use. From rocker/rstudio:4.2.2
- copy the ETL_orchestration folder in container and set the work directory
- Default JAVA or else sqlRender would not install
- Python version 3.10.6
- Switch to user rstudio
- install pip for python3.10
- run renv::restore() with in R to install all the dependencies
-  Switch to root. This is very important.
