### PR TITLE
Changed the finngenid limit as user input in config_template file

### DIFF
--- a/3_etl_code/ETL_Orchestration/R/setup_enviroment_functions.R
+++ b/3_etl_code/ETL_Orchestration/R/setup_enviroment_functions.R
@@ -109,7 +109,8 @@ transform_and_copy_source_tables_to_etl_input <- function(config) {
     sql,
     schema_table_service_sector = config$schema_table_service_sector,
     schema_table_finngenid = config$schema_table_finngenid,
-    schema_etl_input = config$schema_etl_input
+    schema_etl_input = config$schema_etl_input,
+    finngenid_limit = config$finngenid_limit
   )
 
   DatabaseConnector::executeSql(conn, paste(sql, collapse = "\n"))

--- a/3_etl_code/ETL_Orchestration/config/config_template.yml
+++ b/3_etl_code/ETL_Orchestration/config/config_template.yml
@@ -8,6 +8,7 @@ atlasdev:
   # id to source tables, service sector data and finngenid data
   schema_table_service_sector: atlas-development-270609.sandbox_tools_r10.finngen_r10_service_sector_detailed_longitudinal_v2
   schema_table_finngenid: atlas-development-270609.sandbox_tools_r10.finngenid_info_r10_v1
+  finngenid_limit: 1000000
   # id to schema with the input tables for the ETL. Service sector is splint in to registers and copied here.
   schema_etl_input: atlas-development-270609.jgt_etl_input
   # id to schemas with the output omop vocabulary and cdm

--- a/3_etl_code/ETL_Orchestration/sql/setup_transform_service_sector_minimum_finngenid_info_to_etl_input_tables.sql
+++ b/3_etl_code/ETL_Orchestration/sql/setup_transform_service_sector_minimum_finngenid_info_to_etl_input_tables.sql
@@ -61,7 +61,7 @@ SELECT FINNGENID,
        APPROX_BIRTH_DATE,
        FU_END_AGE
 FROM @schema_table_finngenid
-LIMIT 1000;
+LIMIT @finngenid_limit;
 
 
 #


### PR DESCRIPTION
This is for issue #56 

Changed the limit as parameter which can be used for testing purpose.
https://github.com/FINNGEN/ETL/blob/7a5770441527f8c2848030f83e533ea3fb4d07b1/3_etl_code/ETL_Orchestration/sql/setup_transform_service_sector_minimum_finngenid_info_to_etl_input_tables.sql#L64

Now, we can select with finngenid_limit setting which will be passed in setup_environment_functions.R script
https://github.com/FINNGEN/ETL/blob/7a5770441527f8c2848030f83e533ea3fb4d07b1/3_etl_code/ETL_Orchestration/R/setup_enviroment_functions.R#L113

The finngenid_limit value is added to config_template.yml file
https://github.com/FINNGEN/ETL/blob/7a5770441527f8c2848030f83e533ea3fb4d07b1/3_etl_code/ETL_Orchestration/config/config_template.yml#L11

Tested out and works. 