### PR TITLE
Fixed SQLs to include for events when standard and omop domains differ

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_condition_occurrence.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_condition_occurrence.sql
@@ -48,7 +48,8 @@ condition_from_registers_with_source_and_standard_concept_id AS (
   ) AS cmap
   ON CAST(sme.omop_source_concept_id AS INT64) = cmap.concept_id_1
   # Here look for default domain condition and standard domain to be either condition or null to capture non-standard events
-  WHERE sme.default_domain LIKE '%Condition%' AND (cmap.domain_id = 'Condition' OR cmap.domain_id IS NULL)
+  #WHERE sme.default_domain LIKE '%Condition%' AND (cmap.domain_id = 'Condition' OR cmap.domain_id IS NULL)
+  WHERE cmap.domain_id = 'Condition'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Condition%')
 )
 
 # 2 - Shape into condition_occurrence table

--- a/3_etl_code/ETL_Orchestration/sql/etl_device_exposure.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_device_exposure.sql
@@ -51,7 +51,8 @@ device_exposure_from_registers_with_source_and_standard_concept_id AS (
   ) AS cmap
   ON CAST(sme.omop_source_concept_id AS INT64) = cmap.concept_id_1
   # Here look for default domain device and standard domain to be device
-  WHERE sme.default_domain LIKE '%Device%' AND (cmap.domain_id = 'Device' OR cmap.domain_id IS NULL)
+  #WHERE sme.default_domain LIKE '%Device%' AND (cmap.domain_id = 'Device' OR cmap.domain_id IS NULL)
+  WHERE cmap.domain_id = 'Device'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Device%')
 )
 
 # 2 - Shape into device exposure table

--- a/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql
@@ -55,7 +55,8 @@ measurement_from_registers_with_source_and_standard_concept_id AS (
   ) AS cmap
   ON CAST(sme.omop_source_concept_id AS INT64) = cmap.concept_id_1
   # Here look for default domain measurement and standard domain to be measurement
-  WHERE sme.default_domain LIKE '%Meas%' AND (cmap.domain_id = 'Measurement' OR cmap.domain_id IS NULL)
+  #WHERE sme.default_domain LIKE '%Meas%' AND (cmap.domain_id = 'Measurement' OR cmap.domain_id IS NULL)
+  WHERE cmap.domain_id = 'Measurement'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Meas%')
 )
 
 # 2 - Shape into measurement table

--- a/3_etl_code/ETL_Orchestration/sql/etl_observation.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_observation.sql
@@ -53,7 +53,8 @@ observation_from_registers_with_source_and_standard_concept_id AS (
   ) AS cmap
   ON CAST(sme.omop_source_concept_id AS INT64) = cmap.concept_id_1
   # Here look for default domain observation and standard domain to be observation
-  WHERE sme.default_domain LIKE '%Obs%' AND (cmap.domain_id = 'Observation' OR cmap.domain_id IS NULL)
+  #WHERE sme.default_domain LIKE '%Obs%' AND (cmap.domain_id = 'Observation' OR cmap.domain_id IS NULL)
+  WHERE cmap.domain_id = 'Observation'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Obs%')
 )
 
 # 2 - Shape into observation table

--- a/3_etl_code/ETL_Orchestration/sql/etl_procedure_occurrence.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_procedure_occurrence.sql
@@ -48,7 +48,8 @@ procedure_from_registers_with_source_and_standard_concept_id AS (
   ) AS cmap
   ON CAST(sme.omop_source_concept_id AS INT64) = cmap.concept_id_1
   # Here look for default domain procedure and standard domain to be either procedure or null to capture non-standard events
-  WHERE sme.default_domain LIKE '%Procedure%' AND (cmap.domain_id = 'Procedure' OR cmap.domain_id IS NULL)
+  #WHERE sme.default_domain LIKE '%Procedure%' AND (cmap.domain_id = 'Procedure' OR cmap.domain_id IS NULL)
+  WHERE cmap.domain_id = 'Procedure'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Procedure%')
 )
 
 # 2 - Shape into procedure_occurrence table

--- a/3_etl_code/ETL_Orchestration/tests/unittest_etl_observation_table.R
+++ b/3_etl_code/ETL_Orchestration/tests/unittest_etl_observation_table.R
@@ -250,3 +250,30 @@ add_hilmo(
 expect_observation(
   person_id = lookup_person("person_id", person_source_value="FG1006001")
 )
+
+
+# TESTS STANDARD DOMAIN IS NOT SAME AS OMOP DOMAIN ID --------------------------------------------------------------------------------------
+
+# Declare Test - 1007 - Codes with different standard and omop domain values
+# For code V174, we can see that standard domain is Observation but omop domain is Condition.
+declareTest(1007, "etl_observation insert one row in observation when standard domain is Observation even if omop domain is different")
+
+add_finngenid_info(
+  finngenid="FG1007001"
+)
+add_hilmo(
+  finngenid = "FG1007001",
+  source = "INPAT",
+  code1_icd_symptom_operation_code = "V174",
+  icdver = "10",
+  index = "FG1007001-1"
+)
+expect_observation(
+  person_id = lookup_person("person_id", person_source_value="FG1007001"),
+  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+                                                person_id = lookup_person("person_id",person_source_value = "FG1007001"),
+                                                visit_source_value = "SOURCE=INPAT;INDEX=FG1007001-1"),
+  observation_concept_id = as_subquery(438921),
+  observation_source_value = "V174",
+  observation_source_concept_id = as_subquery(45585374)
+)


### PR DESCRIPTION
This is for issue #25 
Changed SQL with the below code
```
 WHERE cmap.domain_id = 'Condition'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Condition%')
```
for condition_occurrence, procedure_occurrence, observation, measurement and device_exposure tables respectively.

Added a unit test in Observation table for code **V174** and it passes the test by adding a row in observation table even though omop domain is "Condition".
https://github.com/FINNGEN/ETL/blob/fd2cd9b3c34a8f5bdceadc526e87217c8f54eb1f/3_etl_code/ETL_Orchestration/sql/etl_observation.sql#L56-L57

The new change does cover all the possible cases
![image](https://user-images.githubusercontent.com/2901531/224711918-3774e297-8022-4ded-b420-ee8cef860fa9.png)
