### PR TITLE
Python libraries will be shared now

### DIFF
--- a/3_etl_code/ETL_Orchestration/Dockerfile
+++ b/3_etl_code/ETL_Orchestration/Dockerfile
@@ -46,11 +46,12 @@ RUN apt-get update -y && \
 RUN wget https://www.python.org/ftp/python/3.10.6/Python-3.10.6.tgz && \
     tar xzf Python-3.10.6.tgz && \
     cd Python-3.10.6 && \
-    ./configure && \
+    ./configure --enable-shared && \
     make -j $(nproc) && \
     make install && \
     cd .. && \
-    rm -rf Python-3.10.6*
+    rm -rf Python-3.10.6* && \
+    ldconfig -v
 
 # Link python
 RUN ln -s /usr/local/bin/python3.10 /usr/local/bin/python


### PR DESCRIPTION
This is for issue #64

Fixed the Python install configuration to be able to share the libraries with other tools. 

Tested the image created and the reticulate package runs command.

![image](https://user-images.githubusercontent.com/2901531/225664494-89e757dd-9e0f-4ebf-b4f5-7818dfce5095.png)
 