### PR TITLE
Add schema_cdm_output parameter in the SQL.

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_condition_era.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_condition_era.sql
@@ -7,8 +7,8 @@
 # - schema_vocab: CDM FinnGen + FinnOMOP + SOURCE vocabularies
 
 
-TRUNCATE TABLE etl_sam_dev_omop.condition_era;
-INSERT INTO etl_sam_dev_omop.condition_era
+TRUNCATE TABLE @schema_cdm_output.condition_era;
+INSERT INTO @schema_cdm_output.condition_era
 (
   condition_era_id,
   person_id,
@@ -35,7 +35,7 @@ FROM (
          co.condition_start_date AS condition_start_date,
          COALESCE(co.condition_end_date, co.condition_start_date) AS condition_end_date,
          co.condition_concept_id AS condition_concept_id
-  FROM etl_sam_dev_omop.condition_occurrence AS co
+  FROM @schema_cdm_output.condition_occurrence AS co
   ) AS d
 INNER JOIN (
   SELECT person_id,
@@ -64,7 +64,7 @@ INNER JOIN (
                      co.condition_start_date AS condition_start_date,
                      COALESCE(co.condition_end_date, co.condition_start_date) AS condition_end_date,
                      co.condition_concept_id AS condition_concept_id
-              FROM etl_sam_dev_omop.condition_occurrence AS co
+              FROM @schema_cdm_output.condition_occurrence AS co
             )
             UNION ALL
             SELECT person_id, condition_concept_id, DATE_ADD(condition_end_date, INTERVAL 60 DAY), 1 AS event_type, NULL
@@ -74,7 +74,7 @@ INNER JOIN (
                      co.condition_start_date AS condition_start_date,
                      COALESCE(co.condition_end_date, co.condition_start_date) AS condition_end_date,
                      co.condition_concept_id AS condition_concept_id
-              FROM etl_sam_dev_omop.condition_occurrence AS co
+              FROM @schema_cdm_output.condition_occurrence AS co
             )
         ) AS rawdata
 ) AS e


### PR DESCRIPTION
This is for issue #69 

The condition era table now have schema_cdm_out parameter for project and dataset which can be seen below
https://github.com/FINNGEN/ETL/blob/fd96b5b17e440650aa8922db82595a63eac3513c/3_etl_code/ETL_Orchestration/sql/etl_condition_era.sql#L10-L11

Changed all such instances within the SQL