### PR TITLE
Added function to export Achilles results to csv file.

### DIFF
--- a/3_etl_code/ETL_Orchestration/Scripts/run_ETL_in_atlasdev.R
+++ b/3_etl_code/ETL_Orchestration/Scripts/run_ETL_in_atlasdev.R
@@ -41,6 +41,13 @@ Achilles::achilles(
   excludeAnalysisIds = c(2004, 532)
 )
 
+exportResultsToCSV(
+  connectionDetails = rlang::exec(DatabaseConnector::createConnectionDetails, !!!config$connection),
+  resultsDatabaseSchema = config$schema_achilles,
+  minCellCount = config$achilles_minimum_cell_count,
+  exportFolder = config$path_achilles_output_folder
+)
+
 #
 # RUN DataQualityDashboard (DQD)
 #

--- a/3_etl_code/ETL_Orchestration/config/config_template.yml
+++ b/3_etl_code/ETL_Orchestration/config/config_template.yml
@@ -23,6 +23,7 @@ atlasdev:
   schema_achilles: atlas-development-270609.jgt_etl_achilles_results
   schema_achilles_scratch: atlas-development-270609.jgt_etl_achilles_scratch
   numThreads: 3
+  achilles_minimum_cell_count: 5
   path_achilles_output_folder: ./output_folders/achilles_output_folder
   path_dqd_output_folder: ./output_folders/dqd_output_folder
   dqd_dbname: FinnGen_dummy


### PR DESCRIPTION
This is for issue #73 

Added the function to export Achilles results to a csv file in the Achilles output folder. The added function can be seen below
https://github.com/FINNGEN/ETL/blob/8e799c409f2e015eab68120461ceeace58be91cf/3_etl_code/ETL_Orchestration/Scripts/run_ETL_in_atlasdev.R#L44-L49

 Also, added the minimum cell count in Achilles export function as config parameter so that user to configure in the yaml file.
The changed config_template file can be seen below
https://github.com/FINNGEN/ETL/blob/8e799c409f2e015eab68120461ceeace58be91cf/3_etl_code/ETL_Orchestration/config/config_template.yml#L26

Tested it out and works.
