### PR TITLE
Fixed export tables to csv files irrespective of size

### DIFF
--- a/3_etl_code/ETL_Orchestration/R/bq_large_tables_export.sh
+++ b/3_etl_code/ETL_Orchestration/R/bq_large_tables_export.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+bucket=""
+table=""
+
+# Parse command line options
+while getopts ":b:t:" opt; do
+  case $opt in
+    b)
+      bucket=$OPTARG
+      ;;
+    t)
+      table=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Print the bucket and table name
+echo "Storage Bucket: $bucket"
+echo "Table Name: $table"
+
+# Set variables
+#bucket="gs://cdm_vocabulary/test"
+#table="concept_relationship"
+
+# Get list of source files
+source_files=($(gsutil ls $bucket/$table-*.csv))
+
+# Remove the first line from all files except the first file
+for ((j=1; j<${#source_files[@]}; j+=1)); do
+  gsutil cat ${source_files[j]} | sed '1d' | gsutil cp - ${source_files[j]}
+done
+
+# Compose files in batches of 32 due to google cloud limit
+source_slices=()
+for ((i=0; i<${#source_files[@]}; i+=32)); do
+  source_slice=("${source_files[@]:$i:32}")
+
+  source_slice_name="$bucket/$table-part$((i/32)).csv"
+  gsutil compose ${source_slice[@]} $source_slice_name
+  source_slices+=("$source_slice_name")
+done
+
+# Compose the final file
+gsutil compose ${source_slices[@]} $bucket/$table.csv
+
+# Delete temporary files
+gsutil -m rm $bucket/$table-*

--- a/3_etl_code/ETL_Orchestration/R/bq_tables_export.sh
+++ b/3_etl_code/ETL_Orchestration/R/bq_tables_export.sh
@@ -4,7 +4,7 @@
 The script takes project, dataset and storage bucket as argeuments
 and outputs all tables in the dataset into folder named output_folders
 An example script looks as below
-bash bq_tables_export.sh -p atlas-development-270609 -d etl_sam_unittest_omop -b gs://cdm_vocabulary -v finngen_finomop_vocabulary.zip
+bash bq_tables_export.sh -p atlas-development-270609 -d etl_sam_unittest_omop -b gs://cdm_vocabulary
 '
 
 
@@ -13,10 +13,9 @@ project=""
 dataset=""
 bucket=""
 outfolder=""
-vocabzip=""
 
 # Parse command line options
-while getopts ":p:d:b:v:" opt; do
+while getopts ":p:d:b:" opt; do
   case $opt in
     p)
       project=$OPTARG
@@ -26,9 +25,6 @@ while getopts ":p:d:b:v:" opt; do
       ;;
     b)
       bucket=$OPTARG
-      ;;
-    v)
-      vocabzip=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -45,46 +41,61 @@ done
 echo "Project: $project"
 echo "Dataset: $dataset"
 echo "Storage Bucket: $bucket"
-echo "vocabzip: $vocabzip"
-
-
-# Get output_folder name
-if [[ "$dataset" == *"_omop"* ]]; then
-        outfolder="cdm"
-elif [[ "$dataset" == *"_vocab"* ]]; then
-        outfolder="vocab"
-elif [[ "$dataset" == *"achilles"* ]]; then
-        outfolder="achilles"
-fi
-echo "Output Folder:  $outfolder"
 
 # Create the local outfolder
-[[ -d $outfolder ]] || mkdir -p ./output_folders/"$outfolder"
-
-# Get vocab zip folder name
-vocabfolder=$(echo "${vocabzip%.*}")
-echo "vocabfolder: $vocabfolder"
+[[ -d ./output_folders/vocab ]] || mkdir -p ./output_folders/vocab
+[[ -d ./output_folders/cdm ]] || mkdir -p ./output_folders/cdm
+[[ -d ./output_folders/achilles ]] || mkdir -p ./output_folders/achilles
 
 # Get table names and schema in json format
 tables=$(bq ls --max_results 1000 "$project:$dataset" | awk 'NR>2{print $1}')
 for table in $tables
 do
-  if [[ "$table" = "concept_ancestor" ]] && [[ "$dataset" == *"_vocab"* ]]; then
-    unzip -p $vocabzip $vocabfolder/CONCEPT_ANCESTOR.csv > ./concept_ancestor.csv
-    gsutil cp ./concept_ancestor.csv $bucket/$outfolder/concept_ancestor.csv
-    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/$outfolder/"$table"_schema.json
-    rm ./concept_ancestor.csv
-  elif [[ "$table" = "concept_relationship" ]] && [[ "$dataset" == *"_vocab"* ]]; then
-    unzip -p $vocabzip $vocabfolder/CONCEPT_RELATIONSHIP.csv > ./concept_relationship.csv
-    gsutil cp ./concept_relationship.csv $bucket/$outfolder/concept_relationship.csv
-    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/$outfolder/"$table"_schema.json
-    rm ./concept_relationship.csv
-  else
-    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/"$outfolder"/"$table".csv
-    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/$outfolder/"$table"_schema.json
+  # VOCAB
+  if [[ "$table" =~ ^(cohort|cohort_definition|concept|concept_class|concept_synonym|domain|drug_strength|relationship|source_to_concept_map|vocabulary)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/vocab/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/vocab/"$table"_schema.json
+  elif [[ "$table" =~ ^(concept_ancestor|concept_relationship)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/vocab/"$table"-*.csv
+    ./R/bq_large_tables_export.sh -b $bucket/vocab -t $table
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/vocab/"$table"_schema.json
+  # CDM
+  elif [[ "$table" =~ ^(care_site|cdm_source|cost|death|device_exposure|dose_era|episode|episode_event|fact_relationship|location|metadata|note|note_nlp|observation_period|payer_plan_period|person|provider|specimen|visit_detail)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/cdm/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/cdm/"$table"_schema.json
+  elif [[ "$table" =~ ^(condition_era|condition_occurrence|drug_era|drug_exposure|measurement|observation|procedure_occurrence|visit_occurrence)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/cdm/"$table"-*.csv
+    ./R/bq_large_tables_export.sh -b $bucket/cdm -t $table
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/cdm/"$table"_schema.json
+  # Achilles - achilles
+  elif [[ "$table" =~ ^(achilles_analysis|achilles_results|achilles_results_dist|cc_results|cohort|cohort_cache|cohort_sensor_stats|cohort_sensor_stats_cache)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/achilles/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/achilles/"$table"_schema.json
+  # Achilles - cohort
+  elif [[ "$table" =~ ^(cohort_inclusion|cohort_inclusion_result|cohort_inclusion_result_cache|cohort_inclusion_stats|cohort_inclusion_stats_cache|cohort_sample_element|cohort_summary_stats|cohort_summary_stats_cache|concept_hierarchy)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/achilles/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/achilles/"$table"_schema.json
+  # Achilles - feas
+  elif [[ "$table" =~ ^(concept_hierarchy|feas_study_inclusion_stats|feas_study_index_stats|feas_study_result)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/achilles/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/achilles/"$table"_schema.json
+  # Achilles - heracles
+  elif [[ "$table" =~ ^(heracles_analysis|heracles_heel_results|heracles_periods|heracles_results|heracles_results_dist)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/achilles/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/achilles/"$table"_schema.json
+  # Achilles - ír
+  elif [[ "$table" =~ ^(ir_analysis_dist|ir_analysis_result|ir_analysis_strata_stats|ir_strata)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/achilles/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/achilles/"$table"_schema.json
+  # Achilles - pathway
+  elif [[ "$table" =~ ^(pathway_analysis_codes|pathway_analysis_events|pathway_analysis_paths|pathway_analysis_stats)$ ]]; then
+    bq extract --destination_format "CSV" --field_delimiter "\t" --print_header=true "$project:$dataset"."$table" "$bucket"/achilles/"$table".csv
+    bq show --format=prettyjson "$project:$dataset"."$table" | jq '.schema.fields' > ./output_folders/achilles/"$table"_schema.json
   fi
 done
 # Download csv files from google cloud bucket to local folder
-gsutil -m cp -r $bucket/$outfolder ./output_folders
+#gsutil -m cp -r $bucket/$outfolder ./output_folders
 # Upload table schema files to google bucket
-gsutil -m cp ./output_folders/$outfolder/*.json $bucket/$outfolder
+gsutil -m cp ./output_folders/vocab/*.json $bucket/vocab
+gsutil -m cp ./output_folders/cdm/*.json $bucket/cdm
+gsutil -m cp ./output_folders/achilles/*.json $bucket/achilles

--- a/3_etl_code/ETL_Orchestration/Scripts/export_tables.sh
+++ b/3_etl_code/ETL_Orchestration/Scripts/export_tables.sh
@@ -1,8 +1,10 @@
 # CDM vocabulary
-./R/bq_tables_export.sh -p atlas-development-270609 -d cdm_vocabulary -b gs://cdm_vocabulary -v C:/Users/Localadmin_padmanab/Documents/FinnGen/ETLv2/finngen_finomop_vocabulary.zip
+./R/bq_tables_export.sh -p atlas-development-270609 -d cdm_vocabulary -b gs://cdm_vocabulary
 
 # CDM output
-./R/bq_tables_export.sh -p atlas-development-270609 -d etl_sam_dev_omop -b gs://cdm_vocabulary -v C:/Users/Localadmin_padmanab/Documents/FinnGen/ETLv2/finngen_finomop_vocabulary.zip
+./R/bq_tables_export.sh -p atlas-development-270609 -d etl_sam_dev_omop -b gs://cdm_vocabulary
 
 # Achilles
-./R/bq_tables_export.sh -p atlas-development-270609 -d etl_sam_dev_achilles -b gs://cdm_vocabulary -v C:/Users/Localadmin_padmanab/Documents/FinnGen/ETLv2/finngen_finomop_vocabulary.zip
+./R/bq_tables_export.sh -p atlas-development-270609 -d etl_sam_dev_achilles -b gs://cdm_vocabulary
+gsutil cp gs://cdm_vocabulary/vocab/cohort.csv gsutil gs://cdm_vocabulary/achilles
+gsutil cp gs://cdm_vocabulary/vocab/cohort_schema.json gs://cdm_vocabulary/achilles


### PR DESCRIPTION
This is for issue #62 

There is problem with table size > 1 GB then this command needs to be changed to with addition of start whereby the table will be split into multiple files. I have fixed it using some bash script that loops over the split files and combines them to a single csv file using gsutil command. The code can be seen below
https://github.com/FINNGEN/ETL/blob/93a10fae3c517d96e9a3bbfa2bed8f420f1956c9/3_etl_code/ETL_Orchestration/R/bq_large_tables_export.sh#L34-L56

This is function specially called for only big tables which can be seen below
https://github.com/FINNGEN/ETL/blob/93a10fae3c517d96e9a3bbfa2bed8f420f1956c9/3_etl_code/ETL_Orchestration/R/bq_tables_export.sh#L54-L69 

The script now takes into account the table names rather than bigquery dataset where in **SANDBOX** we have only one dataset. It still splits into three categories.
- vocab
- cdm
- achilles

I have tested it out and works. The call script is also updated
https://github.com/FINNGEN/ETL/blob/93a10fae3c517d96e9a3bbfa2bed8f420f1956c9/3_etl_code/ETL_Orchestration/Scripts/export_tables.sh#L1-L10

This can be improved in future but this crude way works for very large sandbox files as well.