### PR TITLE
Fixed visits getting 0 as visit_type 

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_visit_occurrence.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_visit_occurrence.sql
@@ -167,23 +167,23 @@ visit_type_fg_codes_preprocessed AS (
     CODE9,
     INDEX,
     CASE
-        WHEN ssdl.SOURCE = 'PRIM_OUT' THEN ssdl.CODE5
-        WHEN ssdl.SOURCE IN ('INPAT','OUTPAT','OPER_IN', 'OPER_OUT', 'PRIM_OUT') AND ssdl.CODE8 IS NULL AND ssdl.CODE9 IS NULL THEN ssdl.CODE5
+        WHEN SOURCE = 'PRIM_OUT' THEN CODE5
+        WHEN SOURCE IN ('INPAT','OUTPAT','OPER_IN', 'OPER_OUT', 'PRIM_OUT') AND CODE8 IS NULL AND CODE9 IS NULL THEN CODE5
         ELSE NULL
     END AS FG_CODE5,
     CASE
-        WHEN ssdl.SOURCE = 'PRIM_OUT' THEN ssdl.CODE6
+        WHEN SOURCE = 'PRIM_OUT' THEN CODE6
         ELSE NULL
     END AS FG_CODE6,
     CASE
-        WHEN ssdl.SOURCE IN ('INPAT','OUTPAT','OPER_IN', 'OPER_OUT')  AND (ssdl.CODE8 IS NOT NULL OR ssdl.CODE9 IS NOT NULL) THEN ssdl.CODE8
+        WHEN SOURCE IN ('INPAT','OUTPAT','OPER_IN', 'OPER_OUT')  AND (CODE8 IS NOT NULL OR CODE9 IS NOT NULL) THEN CODE8
         ELSE NULL
     END AS FG_CODE8,
     CASE
-        WHEN ssdl.SOURCE IN ('INPAT','OUTPAT','OPER_IN', 'OPER_OUT') AND (ssdl.CODE8 IS NOT NULL OR ssdl.CODE9 IS NOT NULL) THEN ssdl.CODE9
+        WHEN SOURCE IN ('INPAT','OUTPAT','OPER_IN', 'OPER_OUT') AND (CODE8 IS NOT NULL OR CODE9 IS NOT NULL) THEN CODE9
         ELSE NULL
     END AS FG_CODE9
-  FROM visits_from_registers AS ssdl
+  FROM visits_from_registers
 ),
 # 2-2 append visit type from fg_codes_info_v2 table based on condition
 # 2-2 Change the processed codes for which visit_type_omop_concept_id iS NULL
@@ -192,30 +192,13 @@ visits_from_registers_with_source_visit_type_id AS (
          vtfgpre.SOURCE,
          vtfgpre.APPROX_EVENT_DAY,
          vtfgpre.approx_end_day,
-         vtfgpre.CODE6,
+         vtfgpre.CODE5, vtfgpre.FG_CODE5,
+         vtfgpre.CODE6, vtfgpre.FG_CODE6,
          vtfgpre.CODE7,
+         vtfgpre.CODE8, vtfgpre.FG_CODE8,
+         vtfgpre.CODE9, vtfgpre.FG_CODE9,
          vtfgpre.INDEX,
-         #fgc.concept_class_id AS visit_type_concept_class_id,
-         #fgc.name_en AS visit_type_name_en,
-         #fgc.name_fi AS visit_type_name_fi,
-         #fgc.code AS visit_type_code,
-         #fgc.omop_concept_id AS visit_type_omop_concept_id,
-         CASE
-              WHEN fgc.omop_concept_id IS NULL AND vtfgpre.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT','PRIM_OUT')  THEN NULL
-              ELSE vtfgpre.FG_CODE5
-         END AS FG_CODE5,
-         CASE
-              WHEN fgc.omop_concept_id IS NULL AND vtfgpre.SOURCE = 'PRIM_OUT' THEN NULL
-              ELSE vtfgpre.FG_CODE6
-         END AS FG_CODE6,
-         CASE
-              WHEN fgc.omop_concept_id IS NULL AND vtfgpre.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN NULL
-              ELSE vtfgpre.FG_CODE8
-         END AS FG_CODE8,
-         CASE
-              WHEN fgc.omop_concept_id IS NULL AND vtfgpre.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN NULL
-              ELSE vtfgpre.FG_CODE9
-         END AS FG_CODE9
+         fgc.omop_concept_id AS visit_type_omop_concept_id
   FROM visit_type_fg_codes_preprocessed AS vtfgpre
   LEFT JOIN ( SELECT SOURCE,
                      FG_CODE5,
@@ -231,17 +214,61 @@ visits_from_registers_with_source_visit_type_id AS (
      vtfgpre.FG_CODE8 IS NOT DISTINCT FROM fgc.FG_CODE8 AND
      vtfgpre.FG_CODE9 IS NOT DISTINCT FROM fgc.FG_CODE9
 ),
-# 2-3 Again append visit type from fg_codes_info_v2 table based on condition
-visits_from_registers_with_source_visit_type_null_id AS (
-  SELECT vfrwsvti.FINNGENID,
+
+# 3- add standard_visit_type_id and
+#    change the source value when the standard concept is null to parent VisitType based on SOURCE
+visits_from_registers_with_source_and_standard_visit_type_id AS (
+  SELECT DISTINCT
+         vfrwsvti.FINNGENID,
          vfrwsvti.SOURCE,
          vfrwsvti.APPROX_EVENT_DAY,
          vfrwsvti.approx_end_day,
          vfrwsvti.CODE6,
          vfrwsvti.CODE7,
          vfrwsvti.INDEX,
-         fgc.omop_concept_id AS visit_type_omop_concept_id
+         CASE
+              WHEN ssmap.concept_id_2 IS NULL AND vfrwsvti.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT','PRIM_OUT') THEN NULL
+              ELSE vfrwsvti.visit_type_omop_concept_id
+         END AS visit_type_omop_concept_id,
+         CASE
+              WHEN ssmap.concept_id_2 IS NULL AND vfrwsvti.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT','PRIM_OUT')  THEN NULL
+              ELSE vfrwsvti.FG_CODE5
+         END AS FG_CODE5,
+         CASE
+              WHEN ssmap.concept_id_2 IS NULL AND vfrwsvti.SOURCE = 'PRIM_OUT' THEN NULL
+              ELSE vfrwsvti.FG_CODE6
+         END AS FG_CODE6,
+         CASE
+              WHEN ssmap.concept_id_2 IS NULL AND vfrwsvti.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN NULL
+              ELSE vfrwsvti.FG_CODE8
+         END AS FG_CODE8,
+         CASE
+              WHEN ssmap.concept_id_2 IS NULL AND vfrwsvti.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN NULL
+              ELSE vfrwsvti.FG_CODE9
+         END AS FG_CODE9
   FROM visits_from_registers_with_source_visit_type_id AS vfrwsvti
+  LEFT JOIN (
+    SELECT cr.concept_id_1, cr.concept_id_2, c.concept_name
+    FROM @schema_vocab.concept_relationship AS cr
+    JOIN @schema_vocab.concept AS c
+    ON cr.concept_id_2 = c.concept_id
+    WHERE cr.relationship_id = 'Maps to' AND c.domain_id IN ('Visit','Metadata')
+  ) AS ssmap
+  ON
+    CAST(vfrwsvti.visit_type_omop_concept_id AS INT64) = ssmap.concept_id_1
+),
+
+# 4- Add the non-standard code
+visits_from_registers_with_source_and_standard_visit_type_null_id AS (
+  SELECT vfrwssti.FINNGENID,
+         vfrwssti.SOURCE,
+         vfrwssti.APPROX_EVENT_DAY,
+         vfrwssti.approx_end_day,
+         vfrwssti.CODE6,
+         vfrwssti.CODE7,
+         vfrwssti.INDEX,
+         fgc.omop_concept_id AS visit_type_omop_concept_id
+  FROM visits_from_registers_with_source_and_standard_visit_type_id AS vfrwssti
   LEFT JOIN ( SELECT SOURCE,
                      FG_CODE5,
                      FG_CODE6,
@@ -250,63 +277,55 @@ visits_from_registers_with_source_visit_type_null_id AS (
                      omop_concept_id
               FROM @schema_table_codes_info
               WHERE vocabulary_id = 'FGVisitType') AS fgc
-  ON vfrwsvti.SOURCE IS NOT DISTINCT FROM fgc.SOURCE AND
-     vfrwsvti.FG_CODE5 IS NOT DISTINCT FROM fgc.FG_CODE5 AND
-     vfrwsvti.FG_CODE6 IS NOT DISTINCT FROM fgc.FG_CODE6 AND
-     vfrwsvti.FG_CODE8 IS NOT DISTINCT FROM fgc.FG_CODE8 AND
-     vfrwsvti.FG_CODE9 IS NOT DISTINCT FROM fgc.FG_CODE9
+  ON vfrwssti.SOURCE IS NOT DISTINCT FROM fgc.SOURCE AND
+     vfrwssti.FG_CODE5 IS NOT DISTINCT FROM fgc.FG_CODE5 AND
+     vfrwssti.FG_CODE6 IS NOT DISTINCT FROM fgc.FG_CODE6 AND
+     vfrwssti.FG_CODE8 IS NOT DISTINCT FROM fgc.FG_CODE8 AND
+     vfrwssti.FG_CODE9 IS NOT DISTINCT FROM fgc.FG_CODE9
 ),
 
-# 3- add standard_visit_type_id
-visits_from_registers_with_source_and_standard_visit_type_id AS (
-  SELECT vfrwsvtni.FINNGENID,
-         vfrwsvtni.SOURCE,
-         vfrwsvtni.APPROX_EVENT_DAY,
-         vfrwsvtni.approx_end_day,
-         vfrwsvtni.CODE6,
-         vfrwsvtni.CODE7,
-         vfrwsvtni.INDEX,
-         vfrwsvtni.visit_type_omop_concept_id,
-         ssmap.concept_id_2
-  FROM visits_from_registers_with_source_visit_type_null_id AS vfrwsvtni
+# 5- Add the standard concept id again
+visits_from_registers_with_source_and_standard_visit_type_full AS (
+  SELECT *
+  FROM visits_from_registers_with_source_and_standard_visit_type_null_id AS vfrwssvtni
   LEFT JOIN (
     SELECT cr.concept_id_1, cr.concept_id_2, c.concept_name
     FROM @schema_vocab.concept_relationship AS cr
       JOIN @schema_vocab.concept AS c
       ON cr.concept_id_2 = c.concept_id
-    WHERE cr.relationship_id = 'Maps to' AND c.domain_id IN ('Visit')
+    WHERE cr.relationship_id = 'Maps to' AND c.domain_id IN ('Visit','Metadata')
   ) AS ssmap
   ON
-    CAST(vfrwsvtni.visit_type_omop_concept_id AS INT64) = ssmap.concept_id_1
-  # remove hilmo inpat visits that are inpatient with ndays=1 or ourtpatient with ndays>1
-  WHERE NOT ( (vfrwsvtni.SOURCE IN ('INPAT','OPER_IN') AND
-               vfrwsvtni.APPROX_EVENT_DAY = vfrwsvtni.approx_end_day AND
+    CAST(vfrwssvtni.visit_type_omop_concept_id AS INT64) = ssmap.concept_id_1
+    # remove hilmo inpat visits that are inpatient with ndays=1 or ourtpatient with ndays>1
+  WHERE NOT ( (vfrwssvtni.SOURCE IN ('INPAT','OPER_IN') AND
+               vfrwssvtni.APPROX_EVENT_DAY = vfrwssvtni.approx_end_day AND
                REGEXP_CONTAINS(ssmap.concept_name,r'^(Inpatient|Rehabilitation|Other|Substance|Emergency Room and Inpatient Visit)'))
               OR
-              (vfrwsvtni.SOURCE IN ('INPAT','OPER_IN') AND
-               vfrwsvtni.APPROX_EVENT_DAY < vfrwsvtni.approx_end_day AND
-               REGEXP_CONTAINS(ssmap.concept_name,r'^(Outpatient|Ambulatory|Home|Emergency Room Visit)')) )
+              (vfrwssvtni.SOURCE IN ('INPAT','OPER_IN') AND
+               vfrwssvtni.APPROX_EVENT_DAY < vfrwssvtni.approx_end_day AND
+               REGEXP_CONTAINS(ssmap.concept_name,r'^(Outpatient|Ambulatory|Home|Emergency Room Visit|Case Management Visit)')) )
 )
 
-# 4- shaper into visit_occurrence_table
+# 6- shaper into visit_occurrence_table
 SELECT
 # visit_occurrence_id
-  ROW_NUMBER() OVER( ORDER BY vfrwssvti.SOURCE, vfrwssvti.INDEX) AS visit_occurrence_id,
+  ROW_NUMBER() OVER( ORDER BY vfrwssvtf.SOURCE, vfrwssvtf.INDEX) AS visit_occurrence_id,
 #person_id,
   p.person_id AS person_id,
 #visit_concept_id,
   CASE
-    WHEN vfrwssvti.concept_id_2 IS NOT NULL THEN vfrwssvti.concept_id_2
+    WHEN vfrwssvtf.concept_id_2 IS NOT NULL THEN vfrwssvtf.concept_id_2
     ELSE 0
   END AS visit_concept_id,
 #visit_start_date,
-  vfrwssvti.APPROX_EVENT_DAY AS visit_start_date,
+  vfrwssvtf.APPROX_EVENT_DAY AS visit_start_date,
 #visit_start_datetime,
-  DATETIME(TIMESTAMP(vfrwssvti.APPROX_EVENT_DAY)) AS visit_start_datetime,
+  DATETIME(TIMESTAMP(vfrwssvtf.APPROX_EVENT_DAY)) AS visit_start_datetime,
 #visit_end_date,
-  vfrwssvti.approx_end_day AS approx_end_day,
+  vfrwssvtf.approx_end_day AS approx_end_day,
 #visit_end_datetime,
-  DATETIME(TIMESTAMP(vfrwssvti.approx_end_day)) AS approx_end_day,
+  DATETIME(TIMESTAMP(vfrwssvtf.approx_end_day)) AS approx_end_day,
 #visit_type_concept_id,
   32879 AS visit_type_concept_id,
 #provider_id,
@@ -318,10 +337,10 @@ SELECT
 #care_site_id,
   NULL AS care_site_id,
 #visit_source_value,
-  CONCAT('SOURCE=',vfrwssvti.SOURCE,';INDEX=',vfrwssvti.INDEX) AS visit_source_value,
+  CONCAT('SOURCE=',vfrwssvtf.SOURCE,';INDEX=',vfrwssvtf.INDEX) AS visit_source_value,
 #visit_source_concept_id,
   CASE
-    WHEN vfrwssvti.visit_type_omop_concept_id IS NOT NULL THEN CAST(vfrwssvti.visit_type_omop_concept_id AS INT64)
+    WHEN vfrwssvtf.visit_type_omop_concept_id IS NOT NULL THEN CAST(vfrwssvtf.visit_type_omop_concept_id AS INT64)
     ELSE 0
   END AS visit_source_concept_id,
 #admitted_from_concept_id,
@@ -335,13 +354,13 @@ SELECT
 #preceding_visit_occurrence_id
   NULL AS preceding_visit_occurrence_id,
 #
-FROM visits_from_registers_with_source_and_standard_visit_type_id AS vfrwssvti
+FROM visits_from_registers_with_source_and_standard_visit_type_full AS vfrwssvtf
 JOIN @schema_cdm_output.person AS p
-ON p.person_source_value = vfrwssvti.FINNGENID
+ON p.person_source_value = vfrwssvtf.FINNGENID
 #LEFT JOIN @schema_cdm_output.provider AS provider
 #ON CASE
-#       WHEN vfrwssvti.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN vfrwssvti.CODE6 = provider.specialty_source_value
-#       WHEN vfrwssvti.SOURCE = 'PRIM_OUT' THEN vfrwssvti.CODE7 = provider.specialty_source_value
+#       WHEN vfrwssvtf.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN vfrwssvtf.CODE6 = provider.specialty_source_value
+#       WHEN vfrwssvtf.SOURCE = 'PRIM_OUT' THEN vfrwssvtf.CODE7 = provider.specialty_source_value
 #       ELSE NULL
 #   END
 LEFT JOIN ( SELECT FG_CODE6,
@@ -351,8 +370,8 @@ LEFT JOIN ( SELECT FG_CODE6,
             WHERE vocabulary_id IN ('MEDSPECfi','ProfessionalCode')
           ) AS fgcp
 ON CASE
-        WHEN vfrwssvti.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN vfrwssvti.CODE6 = fgcp.FG_CODE6
-        WHEN vfrwssvti.SOURCE = 'PRIM_OUT' THEN vfrwssvti.CODE7 = fgcp.FG_CODE7
+        WHEN vfrwssvtf.SOURCE IN ('INPAT','OUTPAT','OPER_IN','OPER_OUT') THEN vfrwssvtf.CODE6 = fgcp.FG_CODE6
+        WHEN vfrwssvtf.SOURCE = 'PRIM_OUT' THEN vfrwssvtf.CODE7 = fgcp.FG_CODE7
         ELSE NULL
    END
 LEFT JOIN @schema_cdm_output.provider AS provider

--- a/3_etl_code/ETL_Orchestration/tests/unittest_etl_visit_occurrence_table.R
+++ b/3_etl_code/ETL_Orchestration/tests/unittest_etl_visit_occurrence_table.R
@@ -30,7 +30,7 @@ expect_visit_occurrence(
   provider_id = NULL,
   care_site_id = NULL,
   visit_source_value = "SOURCE=PURCH;INDEX=FG00301001-1",
-  visit_source_concept_id = as_subquery(2101400101),
+  visit_source_concept_id = as_subquery(2002330101),
   admitted_from_concept_id = as_subquery(0),
   admitted_from_source_value = NULL,
   discharged_to_concept_id = as_subquery(0),
@@ -55,7 +55,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00302001"),
   visit_concept_id = as_subquery(581458),
   visit_source_value = "SOURCE=PURCH;INDEX=FG00302001-1",
-  visit_source_concept_id = as_subquery(2101400101)
+  visit_source_concept_id = as_subquery(2002330101)
 )
 
 add_reimb(
@@ -68,7 +68,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00302001"),
   visit_concept_id = as_subquery(38004193),
   visit_source_value = "SOURCE=REIMB;INDEX=FG00302001-1",
-  visit_source_concept_id = as_subquery(2101400102)
+  visit_source_concept_id = as_subquery(2002330102)
 )
 
 add_canc(
@@ -81,7 +81,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00302001"),
   visit_concept_id = as_subquery(38004268),
   visit_source_value = "SOURCE=CANC;INDEX=FG00302001-1",
-  visit_source_concept_id = as_subquery(2101400103)
+  visit_source_concept_id = as_subquery(2002330103)
 )
 
 add_death(
@@ -94,7 +94,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00302001"),
   visit_concept_id = as_subquery(0),
   visit_source_value = "SOURCE=DEATH;INDEX=FG00302001-1",
-  visit_source_concept_id = as_subquery(2101400104)
+  visit_source_concept_id = as_subquery(2002330104)
 )
 
 
@@ -116,7 +116,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00303001"),
   visit_concept_id = as_subquery(38004193),
   visit_source_value = "SOURCE=PRIM_OUT;INDEX=FG00303001-1",
-  visit_source_concept_id = as_subquery(2101300644)
+  visit_source_concept_id = as_subquery(2002320644)
 )
 
 add_prim_out(
@@ -131,7 +131,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00303001"),
   visit_concept_id = as_subquery(9202),
   visit_source_value = "SOURCE=PRIM_OUT;INDEX=FG00303001-2",
-  visit_source_concept_id = as_subquery(2101300624)
+  visit_source_concept_id = as_subquery(2002320624)
 )
 
 add_prim_out(
@@ -146,7 +146,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00303001"),
   visit_concept_id = as_subquery(38004193),
   visit_source_value = "SOURCE=PRIM_OUT;INDEX=FG00303001-3",
-  visit_source_concept_id = as_subquery(2101300324)
+  visit_source_concept_id = as_subquery(2002320324)
 )
 
 add_prim_out(
@@ -161,7 +161,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00303001"),
   visit_concept_id = as_subquery(5083),
   visit_source_value = "SOURCE=PRIM_OUT;INDEX=FG00303001-4",
-  visit_source_concept_id = as_subquery(2101300274)
+  visit_source_concept_id = as_subquery(2002320274)
 )
 
 
@@ -186,7 +186,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00304001"),
   visit_concept_id = as_subquery(9202),
   visit_source_value = "SOURCE=OUTPAT;INDEX=FG00304001-1",
-  visit_source_concept_id = as_subquery(2101100206)
+  visit_source_concept_id = as_subquery(2002300206)
 )
 
 
@@ -215,7 +215,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00306001"),
   visit_concept_id = as_subquery(9202),
   visit_source_value = "SOURCE=INPAT;INDEX=FG00306001-1",
-  visit_source_concept_id = as_subquery(2101100205)
+  visit_source_concept_id = as_subquery(2002300205)
 )
 
 add_hilmo(
@@ -233,11 +233,11 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00306001"),
   visit_concept_id = as_subquery(9201),
   visit_source_value = "SOURCE=INPAT;INDEX=FG00306001-2",
-  visit_source_concept_id = as_subquery(2101100205)
+  visit_source_concept_id = as_subquery(2002300205)
 )
 
-# Declare Test - 0307 - visit_source_concept_id missing mapping is not skipped
-declareTest(0307, "etl_visit_occurrence sets visit_concept_id to 0 when code in visit_source_concept_id has no mapping")
+# Declare Test - 0307 - visit_source_concept_id missing then mapped to parent visit_type
+declareTest(0307, "etl_visit_occurrence uses parent visit_type when standard concept is 0 for HILMO and PRIM_OUT registries")
 add_finngenid_info(
   finngenid="FG00307001"
 )
@@ -252,9 +252,9 @@ add_hilmo(
 expect_visit_occurrence(
   # visit_occurrence_id rand
   person_id = lookup_person("person_id", person_source_value="FG00307001"),
-  visit_concept_id = as_subquery(0),
+  visit_concept_id = as_subquery(9202),
   visit_source_value = "SOURCE=INPAT;INDEX=FG00307001-1",
-  visit_source_concept_id = as_subquery(2101200101)
+  visit_source_concept_id = as_subquery(2002300205)
 )
 
 # TEST PROVIDER ID ----------------------------------------------------------------------------------------------------
@@ -274,7 +274,7 @@ add_hilmo(
 expect_visit_occurrence(
   # visit_occurrence_id rand
   person_id = lookup_person("person_id", person_source_value="FG00308001"),
-  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2012000101))
+  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2001000101))
 )
 
 # Declare Test - 0309 - CODE7_PROFESSIONAL_CODE from PRIM_OUT is properly mapped to provider_id from provider table
@@ -294,7 +294,7 @@ add_prim_out(
 expect_visit_occurrence(
   # visit_occurrence_id rand
   person_id = lookup_person("person_id", person_source_value="FG00309001"),
-  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2102000735))
+  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2002200735))
 )
 
 # CAUTION: codes 11, 74, 93 exists in both MEDSPECfi and ProfessionalCode
@@ -313,7 +313,7 @@ add_hilmo(
 expect_visit_occurrence(
   # visit_occurrence_id rand
   person_id = lookup_person("person_id", person_source_value="FG00310001"),
-  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2012000111))
+  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2001000111))
 )
 # notice we have to change test id to 0311 but still work with FG00310001 as it checks results from previous add_hilmo
 declareTest(0311, "etl_visit_occurrence DOESNOT map to provider_id in ProfessionalCode for CODE6_SPECIALITY=11 from HILMO")
@@ -326,7 +326,7 @@ add_hilmo(
 expect_visit_occurrence(
   # visit_occurrence_id rand
   person_id = lookup_person("person_id", person_source_value="FG00310001"),
-  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2102000102))
+  provider_id = lookup_provider("provider_id", specialty_source_concept_id = as_subquery(2002200102))
 )
 
 # TEST MISSING OR WRONG MAPPED FGVisitType ------------------------------------------------------------------------------
@@ -351,7 +351,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00312001"),
   visit_concept_id = as_subquery(9202),
   visit_source_value = "SOURCE=OUTPAT;INDEX=FG00312001-1",
-  visit_source_concept_id = as_subquery(2101100206)
+  visit_source_concept_id = as_subquery(2002300206)
 )
 
 # Declare Test - 0313 - For INPAT source with CODE5_SERVICE_SECTOR=99 from HILMO will map to default 9201 Inpatient Visit
@@ -376,7 +376,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00313001"),
   visit_concept_id = as_subquery(9201),
   visit_source_value = "SOURCE=INPAT;INDEX=FG00313001-1",
-  visit_source_concept_id = as_subquery(2101100205)
+  visit_source_concept_id = as_subquery(2002300205)
 )
 
 # Declare Test - 0314 - For PRIM_OUT source with code5_contact_type=-1,code6_service_sector=-1 will map to default 38004193 Case Management Visit
@@ -398,7 +398,7 @@ expect_visit_occurrence(
   person_id = lookup_person("person_id", person_source_value="FG00314001"),
   visit_concept_id = as_subquery(38004193),
   visit_source_value = "SOURCE=PRIM_OUT;INDEX=FG00314001-1",
-  visit_source_concept_id = as_subquery(2101300644)
+  visit_source_concept_id = as_subquery(2002320644)
 )
 
 


### PR DESCRIPTION
This is for issue #79 

Fixed the visit_type_omop_concept_id for wrong or missing visit_types in fg_codes_info_v2 table under 'FGVisitType' vocabulary.
Now they default to the SOURCE visit_type will be considered when the standard concept id is 0 for HILMO and PRIM_OUT registries.