### PR TITLE
Missing condition_concept_id linked to visit occurrence. 

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_visit_occurrence.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_visit_occurrence.sql
@@ -227,12 +227,12 @@ visits_from_registers_with_source_and_standard_visit_type_id AS (
   ON
     CAST(vfrwsvti.visit_type_omop_concept_id AS INT64) = ssmap.concept_id_1
   # remove hilmo inpat visits that are inpatient with ndays=1 or ourtpatient with ndays>1
-  WHERE NOT ( (vfrwsvtni.SOURCE IN ('INPAT','OPER_IN') AND
-                vfrwsvtni.APPROX_EVENT_DAY = vfrwsvtni.approx_end_day AND
+  WHERE NOT ( (vfrwsvti.SOURCE IN ('INPAT','OPER_IN') AND
+                vfrwsvti.APPROX_EVENT_DAY = vfrwsvti.approx_end_day AND
                 REGEXP_CONTAINS(ssmap.concept_name,r'^(Inpatient|Rehabilitation|Other|Substance|Emergency Room and Inpatient Visit)'))
         OR
-        (vfrwsvtni.SOURCE IN ('INPAT','OPER_IN') AND
-               vfrwsvtni.APPROX_EVENT_DAY < vfrwsvtni.approx_end_day AND
+        (vfrwsvti.SOURCE IN ('INPAT','OPER_IN') AND
+               vfrwsvti.APPROX_EVENT_DAY < vfrwsvti.approx_end_day AND
                REGEXP_CONTAINS(ssmap.concept_name,r'^(Outpatient|Ambulatory|Home|Emergency Room Visit)')) )
 )
 


### PR DESCRIPTION
This is for issue #86 

The problem condition_occurrence table showing close to 60% events with condition_concept_id = 0 was having improper visit_occurrence table.
After processing etl_visit_occurrence.sql we ended up with close to 9 million events but there are only 2,703,150 events with 2,118,177 unique events.
The problem with ballooning number of events in final visit_occurrence table was due to this part of the SQL code
https://github.com/FINNGEN/ETL/blob/d9b1b202106214dd4410fdb6d4f232a0f48e1495/3_etl_code/ETL_Orchestration/sql/etl_visit_occurrence.sql#L227-L229

After fixing to properly filter out INPAT and OPER_IN events that map to both Outpatient and Inpatient hospital we ended up with 2,117,895 unique events out of 2,118,177 unique events. The fixed is shown below
https://github.com/FINNGEN/ETL/blob/1a68aef9edd228a4f18d0e5c85aa5d35dd4cce31/3_etl_code/ETL_Orchestration/sql/etl_visit_occurrence.sql#L230-L236

There were around 282 unique events that failed the visit_occurrence SQL code is because of one code in both INPAT and OPER_IN sources.
For both INPAT and OPER_IN sources, CODE5 value is 2 has only possible CODE4 hospital days as 0, 1, NULL in the original data. But in the mock data, we have CODE4 > 1 for CODE5 = 2 for sources INPAT and OPER_IN. The `WHERE` clause above removes such instances.
![inpat_value_2_that_does_not_exist_in_real_data](https://user-images.githubusercontent.com/2901531/228004678-27ae061d-f88c-4c4c-8a1f-8f7141388566.png)

![oper_in_value_2_that_does_not_exist_in_real_data](https://user-images.githubusercontent.com/2901531/228004691-df6b0a0f-fd91-4fdb-8c39-3245d6d342f3.png)

After ignoring this, we ended up with close to **4.4% of concept_ids having value 0 in condition_occurrence table**
![image](https://user-images.githubusercontent.com/2901531/228004773-6b4c0b4b-717d-4a04-8f83-c43fe249ac34.png)
