### PR TITLE
Fixed the plausibility fail observation period.

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_observation_period.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_observation_period.sql
@@ -25,7 +25,7 @@ SELECT
     p.person_id AS person_id,
 # observation_period_start_date
     CASE
-        WHEN p.year_of_birth > 1953 THEN CAST(p.birth_datetime AS DATE)
+        WHEN p.year_of_birth >= 1953 THEN CAST(p.birth_datetime AS DATE)
         ELSE CAST("1953-01-01" AS DATE)
     END AS observation_period_start_date,
 # observation_period_end_date


### PR DESCRIPTION
This is for issue #98 

By adding the `>=` in the SQL while insert `observation_period_start_date` the Plausibility FAIL now PASS with 0 events failing. This can be seen in dummy data
![image](https://user-images.githubusercontent.com/2901531/229077565-f37d52cc-d8fd-4bd1-a8f5-bf4a16607d1b.png)


