### PR TITLE
Fixed Device Exposure source concept id SQL code

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_device_exposure.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_device_exposure.sql
@@ -92,7 +92,7 @@ SELECT
   defrwsasci.CODE1 AS device_source_value,
 # device_source_concept_id
   CASE
-    WHEN defrwsasci.omop_source_concept_id IS NULL THEN CAST(defrwsasci.omop_source_concept_id AS INT64)
+    WHEN defrwsasci.omop_source_concept_id IS NOT NULL THEN CAST(defrwsasci.omop_source_concept_id AS INT64)
     ELSE 0
   END AS device_source_concept_id,
 # unit_concept_id


### PR DESCRIPTION
This is for issue #101 

The SQL code is now corrected
https://github.com/FINNGEN/ETL/blob/ae35444706610905396179b7564ea383ddb9d612/3_etl_code/ETL_Orchestration/sql/etl_device_exposure.sql#L93-L97 

And the DQ check for number of 0 in `device_source_concept_id` will return 0 and will result in PASS
![image](https://user-images.githubusercontent.com/2901531/229116942-e41ba3c1-c782-4909-ba00-3c2fe5ef7b8c.png)
