### PR TITLE
Fixed missing zero measurement concept id. 

### DIFF
--- a/3_etl_code/ETL_Orchestration/R/TestFramework.R
+++ b/3_etl_code/ETL_Orchestration/R/TestFramework.R
@@ -81,7 +81,7 @@ initFramework <- function() {
   defaults$icdver <- '10'
   defaults$category <- 'U'
   defaults$index <- ''
-  assign('death', defaults, envir = frameworkContext$defaultValues)
+  assign('death_register', defaults, envir = frameworkContext$defaultValues)
 
   defaults <- list()
   defaults$finngenid <- 'FG00000000'
@@ -335,7 +335,7 @@ set_defaults_reimb <- function(finngenid, source, event_age, approx_event_day, c
   invisible(defaults)
 }
 
-set_defaults_death <- function(finngenid, source, event_age, approx_event_day, code1_cause_of_death, code2_na, code3_na, code4_na, icdver, category, index) {
+set_defaults_death_register <- function(finngenid, source, event_age, approx_event_day, code1_cause_of_death, code2_na, code3_na, code4_na, icdver, category, index) {
   defaults <- get('death', envir = frameworkContext$defaultValues)
   if (!missing(finngenid)) {
     defaults$finngenid <- finngenid
@@ -524,7 +524,7 @@ get_defaults_reimb <- function() {
   return(defaults)
 }
 
-get_defaults_death <- function() {
+get_defaults_death_register <- function() {
   defaults <- get('death', envir = frameworkContext$defaultValues)
   return(defaults)
 }
@@ -936,7 +936,7 @@ add_reimb <- function(finngenid, source, event_age, approx_event_day, code1_kela
   invisible(NULL)
 }
 
-add_death <- function(finngenid, source, event_age, approx_event_day, code1_cause_of_death, code2_na, code3_na, code4_na, icdver, category, index) {
+add_death_register <- function(finngenid, source, event_age, approx_event_day, code1_cause_of_death, code2_na, code3_na, code4_na, icdver, category, index) {
   defaults <- get('death', envir = frameworkContext$defaultValues)
   fields <- c()
   values <- c()
@@ -11951,7 +11951,7 @@ generateInsertSql <- function(databaseSchema = NULL) {
   insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.finngenid_info;")
   insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.hilmo;")
   insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.reimb;")
-  insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.death;")
+  insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.death_register;")
   insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.prim_out;")
   insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.canc;")
   insertSql <- c(insertSql, "TRUNCATE TABLE @cdm_database_schema.purch;")

--- a/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql
@@ -51,12 +51,15 @@ measurement_from_registers_with_source_and_standard_concept_id AS (
     FROM @schema_vocab.concept_relationship AS cr
     JOIN @schema_vocab.concept AS c
     ON cr.concept_id_2 = c.concept_id
-    WHERE cr.relationship_id = 'Maps to' AND c.domain_id ='Measurement'
+    #WHERE cr.relationship_id = 'Maps to' AND c.domain_id ='Measurement'
+    WHERE cr.relationship_id = 'Maps to' AND c.domain_id LIKE '%Meas%'
   ) AS cmap
   ON CAST(sme.omop_source_concept_id AS INT64) = cmap.concept_id_1
   # Here look for default domain measurement and standard domain to be measurement
   #WHERE sme.default_domain LIKE '%Meas%' AND (cmap.domain_id = 'Measurement' OR cmap.domain_id IS NULL)
-  WHERE cmap.domain_id = 'Measurement'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Meas%')
+  #WHERE cmap.domain_id = 'Measurement'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Meas%')
+  WHERE (cmap.domain_id LIKE '%Meas%' AND sme.default_domain != 'Procedure')  OR
+        (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Meas%')
 )
 
 # 2 - Shape into measurement table

--- a/3_etl_code/ETL_Orchestration/tests/unittest_etl_measurement_table.R
+++ b/3_etl_code/ETL_Orchestration/tests/unittest_etl_measurement_table.R
@@ -213,29 +213,30 @@ expect_measurement(
 
 # TESTS CODES WITH NON-STANDARD MAPPING BUT WITHOUT STANDARD MAPPING ------------------------------------------------------------
 
+# All of the non-standard measurement concepts are mapped with standard concept making this test not testable
 # Declare Test - 0805 - Codes with non-standard mapping and without standard mapping take domain from concept table if not from source and vocab
-declareTest(0805, "etl_measurement inserts one event for a code with non-standard mapping in measurement domain and without standard mapping")
+#declareTest(0805, "etl_measurement inserts one event for a code with non-standard mapping in measurement domain and without standard mapping")
 
-add_finngenid_info(
-  finngenid="FG0805001"
-)
-add_hilmo(
-  finngenid = "FG0805001",
-  source = "INPAT",
-  code1_icd_symptom_operation_code = "78719",
-  icdver = "8",
-  category = "1",
-  index = "FG0805001-1"
-)
-expect_measurement(
-  person_id = lookup_person("person_id", person_source_value="FG0805001"),
-  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
-                                                person_id = lookup_person("person_id",person_source_value = "FG0805001"),
-                                                visit_source_value = "SOURCE=INPAT;INDEX=FG0805001-1"),
-  measurement_concept_id = as_subquery(0),
-  measurement_source_value = "78719",
-  measurement_source_concept_id = as_subquery(2000305261)
-)
+#add_finngenid_info(
+#  finngenid="FG0805001"
+#)
+#add_hilmo(
+#  finngenid = "FG0805001",
+#  source = "INPAT",
+#  code1_icd_symptom_operation_code = "78719",
+#  icdver = "8",
+#  category = "1",
+#  index = "FG0805001-1"
+#)
+#expect_measurement(
+#  person_id = lookup_person("person_id", person_source_value="FG0805001"),
+#  visit_occurrence_id = lookup_visit_occurrence("visit_occurrence_id",
+#                                                person_id = lookup_person("person_id",person_source_value = "FG0805001"),
+#                                                visit_source_value = "SOURCE=INPAT;INDEX=FG0805001-1"),
+#  measurement_concept_id = as_subquery(0),
+#  measurement_source_value = "78719",
+#  measurement_source_concept_id = as_subquery(2000305261)
+#)
 
 # TESTS CODES WITHOUT NON-STANDARD MAPPING --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is for issue #107 

Adding `LIKE` when capturing measurements fixed this problem. The SQL code is fixed as shown below
https://github.com/FINNGEN/ETL/blob/52643bbfd340a1c5259ef8a3eeb6c25dff246a25/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql#L45-L63

However, there was a special case of **PROCEDURE** events being put in **MEASUREMENT** table because of improper `domain_id` for ICD10 code **Z031**. 

The omop concept id of **Z031** ICD10 having domain_id as **PROCEDURE** code can be seen below
![image](https://user-images.githubusercontent.com/2901531/229568858-de082c06-3466-48f1-a9f4-12f1862ef693.png)

But it maps to **two standard concept ids** which are **4048727 with domain Measurement** and **4062771 with domain Procedure**. 
![image](https://user-images.githubusercontent.com/2901531/229569454-148ea153-77ad-4af1-996e-8c5389dfafa5.png)

Because of improper `domain_id`, some of the **PROCEDURE** events were inserted into **MEASUREMENT** table and to fix that I have added **WHICH WORKS FOR NOW**
https://github.com/FINNGEN/ETL/blob/52643bbfd340a1c5259ef8a3eeb6c25dff246a25/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql#L61

The result is that now there are no events in **MEASUREMENT** table with missing `measurement_concept_id` and all of them are properly mapped
![image](https://user-images.githubusercontent.com/2901531/229570050-f74068ab-1669-4a06-ace0-9c9c12cc6b4b.png)

