### PR TITLE
Fixed an error in ERA tables that gives huge gap values in drug era

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_condition_era.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_condition_era.sql
@@ -40,7 +40,7 @@ FROM (
 INNER JOIN (
   SELECT person_id,
          condition_concept_id,
-         DATE_ADD(event_date, INTERVAL 60 DAY) AS end_date
+         DATE_ADD(event_date, INTERVAL -60 DAY) AS end_date
   FROM(
   SELECT rawdata.person_id,
          rawdata.condition_concept_id,

--- a/3_etl_code/ETL_Orchestration/sql/etl_drug_era.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_drug_era.sql
@@ -47,7 +47,7 @@ FROM (
 INNER JOIN (
   SELECT person_id,
          ingredient_concept_id,
-         DATE_ADD(event_date, INTERVAL 120 DAY) AS end_date
+         DATE_ADD(event_date, INTERVAL -120 DAY) AS end_date
   FROM(
   SELECT rawdata.person_id,
          rawdata.ingredient_concept_id,


### PR DESCRIPTION
This is for issue #103 

Now we get close to 7% records in `DRUG_ERA` table
![image](https://user-images.githubusercontent.com/2901531/229577168-fd529ee9-3e9d-43ee-9a69-365cd8941d3e.png)

The code that was causing the error is fixed.
https://github.com/FINNGEN/ETL/blob/ce89e52bf2a3e5704d40d0bc49b9c65800308650/3_etl_code/ETL_Orchestration/sql/etl_drug_era.sql#L50

This reverts back to `drug_exposure_end_date` by subtracting **120 days** which were already added to find drug eras
https://github.com/FINNGEN/ETL/blob/ce89e52bf2a3e5704d40d0bc49b9c65800308650/3_etl_code/ETL_Orchestration/sql/etl_drug_era.sql#L83