### PR TITLE
Fixed the correct domain for measurement ETL

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql
@@ -51,15 +51,14 @@ measurement_from_registers_with_source_and_standard_concept_id AS (
     FROM @schema_vocab.concept_relationship AS cr
     JOIN @schema_vocab.concept AS c
     ON cr.concept_id_2 = c.concept_id
-    #WHERE cr.relationship_id = 'Maps to' AND c.domain_id ='Measurement'
-    WHERE cr.relationship_id = 'Maps to' AND c.domain_id LIKE '%Meas%'
+    WHERE cr.relationship_id = 'Maps to' AND c.domain_id ='Measurement'
   ) AS cmap
   ON CAST(sme.omop_source_concept_id AS INT64) = cmap.concept_id_1
   # Here look for default domain measurement and standard domain to be measurement
   #WHERE sme.default_domain LIKE '%Meas%' AND (cmap.domain_id = 'Measurement' OR cmap.domain_id IS NULL)
-  #WHERE cmap.domain_id = 'Measurement'  OR  (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Meas%')
-  WHERE (cmap.domain_id LIKE '%Meas%' AND sme.default_domain != 'Procedure')  OR
-        (cmap.domain_id IS NULL AND sme.default_domain LIKE '%Meas%')
+  #WHERE cmap.domain_id = 'Measurement'  OR  (cmap.domain_id IS NULL AND sme.default_domain = 'Meas/Procedure')
+  WHERE (cmap.domain_id = 'Measurement' AND sme.default_domain != 'Procedure')  OR
+        (cmap.domain_id IS NULL AND sme.default_domain IN ('Measurement','Meas/Procedure'))
 )
 
 # 2 - Shape into measurement table


### PR DESCRIPTION
This is for issue #110 

The SQL is changed to include only **Measurement** and **Meas/Procedure** values in `default_domain`
https://github.com/FINNGEN/ETL/blob/a5c8eb4e7e593d96966c0e94ee37af0133c96486/3_etl_code/ETL_Orchestration/sql/etl_measurement.sql#L60-L61

Tested it out and all of them **PASS**

Checked if we get errors due to **missing measurement_concept_id** or **concept ids not in Measurement domain**

**MISSING measurement_concept_id**
![image](https://user-images.githubusercontent.com/2901531/229798830-460b4b31-a5b5-426d-9778-e41eb9f86552.png)

The result is now **0%** violations
![image](https://user-images.githubusercontent.com/2901531/229798930-0da719af-5b56-44b6-851f-ad25394e5fa7.png)

**concept_ids not in Measurement domain**
![image](https://user-images.githubusercontent.com/2901531/229799027-8009ba9c-79dc-418c-bcda-f53507dad9b2.png)

The result is now **0%** violations
![image](https://user-images.githubusercontent.com/2901531/229799132-c3ce624c-677a-47ef-9559-bed7dd090b30.png)

