### PR TITLE
Fixed Python virtual environment name in renv.lock file

### DIFF
--- a/3_etl_code/ETL_Orchestration/renv.lock
+++ b/3_etl_code/ETL_Orchestration/renv.lock
@@ -11,7 +11,7 @@
   "Python": {
     "Version": "3.10.6",
     "Type": "virtualenv",
-    "Name": "/Users/javier/.virtualenvs/etl-test"
+    "Name": "etl-test"
   },
   "Packages": {
     "Achilles": {


### PR DESCRIPTION
This is for issue #123 

`renv.lock` file is now updated with name 
https://github.com/FINNGEN/ETL/blob/6229a6e30098c776926b5bf02c86da62ff831668/3_etl_code/ETL_Orchestration/renv.lock#L14

