### PR TITLE
Made changes to unittest add_finngenid function to check BIOBANK visits

### DIFF
--- a/3_etl_code/ETL_Orchestration/tests/unittest_etl_visit_occurrence_table.R
+++ b/3_etl_code/ETL_Orchestration/tests/unittest_etl_visit_occurrence_table.R
@@ -412,10 +412,10 @@ add_finngenid_info(
   sex = "female",
   height = as_subquery(177),
   height_age = NULL,
-  weight = as_subquery(72),
+  weight = NULL,
   weight_age = NULL,
-  smoke2 = "no",
-  smoke3 = "never",
+  smoke2 = NULL,
+  smoke3 = NULL,
   smoke5 = NULL,
   smoke_age = NULL,
   regionofbirth = as_subquery(1),
@@ -452,6 +452,7 @@ add_finngenid_info(
   finngenid="FG00316001",
   bl_year = as_subquery(2000),
   bl_age = as_subquery(40.0),
+  height = as_subquery(177),
   approx_birth_date = "1954-01-01",
   fu_end_age = as_subquery(60.0)
 )
@@ -470,6 +471,7 @@ add_finngenid_info(
   finngenid="FG00317001",
   bl_year = as_subquery(2000),
   bl_age = as_subquery(40.25),
+  height = as_subquery(177),
   approx_birth_date = NULL
 )
 


### PR DESCRIPTION
This is for issue #45 

As the selection of BIOBANK visit is changed only when either BMI or Height or Smoking codes are not NULL
https://github.com/FINNGEN/ETL/blob/da866a51a551df5a644be9ce9ae5fa9070455952/3_etl_code/ETL_Orchestration/sql/etl_visit_occurrence.sql#L154-L177

But the default values in `TestFramework.R` are all NULL
https://github.com/FINNGEN/ETL/blob/da866a51a551df5a644be9ce9ae5fa9070455952/3_etl_code/ETL_Orchestration/R/TestFramework.R#L18-L37

The default values are changed to NULL so as to not make conflict with other Unit test runs.

It is necessary to reflect the Unit test for visit_occurrence on BIOBANK visits should have one of the codes being not NULL or else the test fails.
https://github.com/FINNGEN/ETL/blob/da866a51a551df5a644be9ce9ae5fa9070455952/3_etl_code/ETL_Orchestration/tests/unittest_etl_visit_occurrence_table.R#L406-L427

All BIOBANK related visit tests PASS.