### PR TITLE
Achilles now has table with RC, DRC, PC and DPC

### DIFF
--- a/3_etl_code/ETL_Orchestration/sql/achilles_result_concept_count.sql
+++ b/3_etl_code/ETL_Orchestration/sql/achilles_result_concept_count.sql
@@ -1,0 +1,120 @@
+/************************************************/
+/***** Create record and person count table *****/
+/************************************************/
+
+IF OBJECT_ID('@schema_achilles.achilles_result_concept_count', 'U') IS NOT NULL
+DROP TABLE @schema_achilles.achilles_result_concept_count;
+
+
+CREATE TABLE @schema_achilles.achilles_result_concept_count
+(
+  concept_id                INT,
+  record_count              bigint,
+  descendant_record_count   bigint,
+  person_count              bigint,
+  descendant_person_count   bigint
+);
+
+
+/**********************************************/
+/***** Populate record/person count table *****/
+/**********************************************/
+
+WITH concepts AS (
+    SELECT
+        CAST(ancestor_concept_id AS VARCHAR)   ancestor_id,
+        CAST(descendant_concept_id AS VARCHAR) descendant_id
+    FROM @schema_vocab.concept_ancestor ca
+UNION
+SELECT
+    CAST(concept_id AS VARCHAR) ancestor_id,
+    CAST(concept_id AS VARCHAR) descendant_id
+FROM @schema_vocab.concept c
+), counts AS (
+SELECT stratum_1 concept_id, MAX (count_value) agg_count_value
+FROM @schema_achilles.achilles_results
+WHERE analysis_id IN (2, 4, 5, 201, 225, 301, 325, 401, 425, 501, 505, 525, 601, 625, 701, 725, 801, 825,
+    826, 827, 901, 1001, 1201, 1203, 1425, 1801, 1825, 1826, 1827, 2101, 2125, 2301)
+    /* analyses:
+          Number of persons by gender
+         Number of persons by race
+         Number of persons by ethnicity
+         Number of visit occurrence records, by visit_concept_id
+         Number of visit_occurrence records, by visit_source_concept_id
+         Number of providers by specialty concept_id
+         Number of provider records, by specialty_source_concept_id
+         Number of condition occurrence records, by condition_concept_id
+         Number of condition_occurrence records, by condition_source_concept_id
+         Number of records of death, by cause_concept_id
+         Number of death records, by death_type_concept_id
+         Number of death records, by cause_source_concept_id
+         Number of procedure occurrence records, by procedure_concept_id
+         Number of procedure_occurrence records, by procedure_source_concept_id
+         Number of drug exposure records, by drug_concept_id
+         Number of drug_exposure records, by drug_source_concept_id
+         Number of observation occurrence records, by observation_concept_id
+         Number of observation records, by observation_source_concept_id
+         Number of observation records, by value_as_concept_id
+         Number of observation records, by unit_concept_id
+         Number of drug era records, by drug_concept_id
+         Number of condition era records, by condition_concept_id
+         Number of visits by place of service
+         Number of visit_occurrence records, by discharge_to_concept_id
+         Number of payer_plan_period records, by payer_source_concept_id
+         Number of measurement occurrence records, by observation_concept_id
+         Number of measurement records, by measurement_source_concept_id
+         Number of measurement records, by value_as_concept_id
+         Number of measurement records, by unit_concept_id
+         Number of device exposure records, by device_concept_id
+         Number of device_exposure records, by device_source_concept_id
+         Number of location records, by region_concept_id
+    */
+GROUP BY stratum_1
+UNION
+SELECT stratum_2 AS concept_id, SUM (count_value) AS agg_count_value
+FROM @schema_achilles.achilles_results
+WHERE analysis_id IN (405, 605, 705, 805, 807, 1805, 1807, 2105)
+    /* analyses:
+         Number of condition occurrence records, by condition_concept_id by condition_type_concept_id
+         Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id
+         Number of drug exposure records, by drug_concept_id by drug_type_concept_id
+         Number of observation occurrence records, by observation_concept_id by observation_type_concept_id
+         Number of observation occurrence records, by observation_concept_id and unit_concept_id
+         Number of observation occurrence records, by measurement_concept_id by measurement_type_concept_id
+         Number of measurement occurrence records, by measurement_concept_id and unit_concept_id
+         Number of device exposure records, by device_concept_id by device_type_concept_id
+        but this subquery only gets the type or unit concept_ids, i.e., stratum_2
+    */
+GROUP BY stratum_2
+    ), counts_person AS (
+SELECT stratum_1 concept_id, MAX (count_value) agg_count_value
+FROM @schema_achilles.achilles_results
+WHERE analysis_id IN (200, 400, 600, 700, 800, 900, 1000, 1300, 1800, 2100, 2200)
+    /* analyses:
+        Number of persons with at least one visit occurrence, by visit_concept_id
+        Number of persons with at least one condition occurrence, by condition_concept_id
+        Number of persons with at least one procedure occurrence, by procedure_concept_id
+        Number of persons with at least one drug exposure, by drug_concept_id
+        Number of persons with at least one observation occurrence, by observation_concept_id
+        Number of persons with at least one drug era, by drug_concept_id
+        Number of persons with at least one condition era, by condition_concept_id
+        Number of persons with at least one visit detail, by visit_detail_concept_id
+        Number of persons with at least one measurement occurrence, by measurement_concept_id
+        Number of persons with at least one device exposure, by device_concept_id
+        Number of persons with at least one note by  note_type_concept_id
+    */
+GROUP BY stratum_1)
+
+INSERT INTO @schema_achilles.achilles_result_concept_count (concept_id, record_count, descendant_record_count, person_count, descendant_person_count)
+SELECT
+    CAST(concepts.ancestor_id AS INT)  concept_id,
+    isnull(max(c1.agg_count_value), 0) record_count,
+    isnull(sum(c2.agg_count_value), 0) descendant_record_count,
+    isnull(max(c3.agg_count_value), 0) person_count,
+    isnull(sum(c4.agg_count_value), 0) descendant_person_count
+FROM concepts
+         LEFT JOIN counts c1 ON concepts.ancestor_id = c1.concept_id
+         LEFT JOIN counts c2 ON concepts.descendant_id = c2.concept_id
+         LEFT JOIN counts_person c3 ON concepts.ancestor_id = c3.concept_id
+         LEFT JOIN counts_person c4 ON concepts.descendant_id = c4.concept_id
+GROUP BY concepts.ancestor_id;


### PR DESCRIPTION
This is for issue #129 

For Atlas docker version 2.13 or > 2.11, there should be `achilles_result_concept_count` table within CDM database from which WebAPI gets information of RC, DRC, PC and DPC values of concepts both standard and non-standard.

This table is not needed for current Atlas in Sandbox now but only for Atlas docker.

Atlas docker now gives proper counts
![image](https://github.com/FINNGEN/ETL/assets/2901531/0b9182cb-de31-4fe0-9844-aa6542938e12)

