### PR TITLE
Added QC check for duplicate FINNGENIDs for same SOURCE+INDEX

### DIFF
--- a/3_etl_code/ETL_Orchestration/Scripts/run_min_QC.R
+++ b/3_etl_code/ETL_Orchestration/Scripts/run_min_QC.R
@@ -22,6 +22,7 @@ qcSql <- SqlRender::readSql("sql/qc_input_data.sql")
 qcSql <- SqlRender::render(
   qcSql,
   schema_etl_input = config$schema_etl_input,
+  schema_table_service_sector = config$schema_table_service_sector,
   warnOnMissingParameters = FALSE
 )
 #qcSql |> clipr::write_clip()


### PR DESCRIPTION
This is for #152 

SOURCE+INDEX should point to Unique FINNGENID. Any SOURCE+INDEX combination points to more than one FINNGENID will fail the test. 

The test does not FAIL.