### PR TITLE
Updated Achilles and added achilles concept count sql

### DIFF
--- a/3_etl_code/ETL_Orchestration/Scripts/run_ETL_in_atlasdev.R
+++ b/3_etl_code/ETL_Orchestration/Scripts/run_ETL_in_atlasdev.R
@@ -15,7 +15,7 @@ source("config/run_config.R")
 #
 log4r::info(logger, "Run ETL")
 
-run_etl_steps(logger, config, run_config)
+run_etl_steps(logger, config, run_config |> dplyr::filter(step_name != "achilles_result_concept_count") )
 
 
 
@@ -49,8 +49,18 @@ Achilles::exportResultsToCSV(
 )
 
 #
-# RUN DataQualityDashboard (DQD)
+# Fill Achilles result concept count table
 #
+
+log4r::info(logger, "Fill Achilles result concept count table")
+
+run_etl_steps(logger, config, run_config |> dplyr::filter(step_name == "achilles_result_concept_count") )
+
+#
+# RUN Data Quality Dashboard (DQD)
+#
+
+log4r::info(logger, "Running Data Quality Dashboard")
 
 out <- DataQualityDashboard::executeDqChecks(
   connectionDetails = rlang::exec(DatabaseConnector::createConnectionDetails, !!!config$connection),

--- a/3_etl_code/ETL_Orchestration/config/run_config_template.R
+++ b/3_etl_code/ETL_Orchestration/config/run_config_template.R
@@ -20,4 +20,5 @@ run_config <- tibble::tribble(
   # "condition_era" , here::here("sql/etl_condition_era.sql"), "", TRUE, FALSE, # set test always to FALSE
   # "cdm_source" , here::here("sql/etl_cdm_source.sql"), "", TRUE, FALSE, # set test always to FALSE
   # "webapi" , here::here("sql/etl_webapi_bigquery.sql"), "", TRUE, FALSE, # set test always to FALSE
+  # "achilles_result_concept_count" , here::here("sql/etl_achilles_result_concept_count.sql"), "", TRUE, FALSE, # set test always to FALSE
 )

--- a/3_etl_code/ETL_Orchestration/renv.lock
+++ b/3_etl_code/ETL_Orchestration/renv.lock
@@ -11,21 +11,19 @@
   "Python": {
     "Version": "3.10.6",
     "Type": "virtualenv",
-    "Name": "etl-test"
+    "Name": "C:/Users/Localadmin_padmanab/Documents/.virtualenvs/etl-test"
   },
   "Packages": {
     "Achilles": {
       "Package": "Achilles",
-      "Version": "1.7",
+      "Version": "1.7.1",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "OHDSI",
       "RemoteRepo": "Achilles",
-      "RemoteRef": "main",
-      "RemoteSha": "a9144b2f3119055b76dfe8e9d798654558127fe3",
-      "Remotes": "github::OHDSI/Castor",
-      "Remotes": "github::OHDSI/Castor",
+      "RemoteRef": "52e28f78648f5d932c509f42c8d817b120c51327",
+      "RemoteSha": "52e28f78648f5d932c509f42c8d817b120c51327",
       "Requirements": [
         "DatabaseConnector",
         "ParallelLogger",
@@ -36,9 +34,10 @@
         "jsonlite",
         "lubridate",
         "readr",
-        "rjson"
+        "rlang",
+        "tseries"
       ],
-      "Hash": "19078f3f3d68986a26fa8b1c112e6970"
+      "Hash": "9f32a6570056cc21e54ad180984b4cda"
     },
     "DBI": {
       "Package": "DBI",
@@ -182,6 +181,18 @@
       ],
       "Hash": "ceb0dffff2624fd7cade5d59b2522acc"
     },
+    "TTR": {
+      "Package": "TTR",
+      "Version": "0.24.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "curl",
+        "xts",
+        "zoo"
+      ],
+      "Hash": "1acd2b3db6e118dd161ee6cabedc4d4e"
+    },
     "assertthat": {
       "Package": "assertthat",
       "Version": "0.2.1",
@@ -289,6 +300,16 @@
         "utils"
       ],
       "Hash": "e8a1e41acf02548751f45c718d55aa6a"
+    },
+    "curl": {
+      "Package": "curl",
+      "Version": "5.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "411ca2c03b1ce5f548345d2fc2685f7a"
     },
     "data.table": {
       "Package": "data.table",
@@ -584,6 +605,32 @@
       ],
       "Hash": "d71c815267c640f17ddbf7f16144b4bb"
     },
+    "quadprog": {
+      "Package": "quadprog",
+      "Version": "1.5-8",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "5f919ae5e7f83a6f91dcf2288943370d"
+    },
+    "quantmod": {
+      "Package": "quantmod",
+      "Version": "0.4.26",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "TTR",
+        "curl",
+        "jsonlite",
+        "methods",
+        "xts",
+        "zoo"
+      ],
+      "Hash": "59321b609790f8ccf92145810e4dd507"
+    },
     "rJava": {
       "Package": "rJava",
       "Version": "1.0-6",
@@ -658,16 +705,6 @@
         "withr"
       ],
       "Hash": "86c441bf33e1d608db773cb94b848458"
-    },
-    "rjson": {
-      "Package": "rjson",
-      "Version": "0.2.21",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "f9da75e6444e95a1baf8ca24909d63b9"
     },
     "rlang": {
       "Package": "rlang",
@@ -787,6 +824,23 @@
       ],
       "Hash": "847a9d113b78baca4a9a8639609ea228"
     },
+    "tseries": {
+      "Package": "tseries",
+      "Version": "0.10-55",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "graphics",
+        "jsonlite",
+        "quadprog",
+        "quantmod",
+        "stats",
+        "utils",
+        "zoo"
+      ],
+      "Hash": "8a3928cb53aca9921f0db707550dfa84"
+    },
     "tzdb": {
       "Package": "tzdb",
       "Version": "0.3.0",
@@ -885,12 +939,39 @@
       ],
       "Hash": "40682ed6a969ea5abfd351eb67833adc"
     },
+    "xts": {
+      "Package": "xts",
+      "Version": "0.13.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "zoo"
+      ],
+      "Hash": "7a7e2b2f6ef5fa41fb766d2a885af39e"
+    },
     "yaml": {
       "Package": "yaml",
       "Version": "2.3.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "0d0056cc5383fbc240ccd0cb584bf436"
+    },
+    "zoo": {
+      "Package": "zoo",
+      "Version": "1.8-12",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "lattice",
+        "stats",
+        "utils"
+      ],
+      "Hash": "5c715954112b45499fb1dadc6ee6ee3e"
     }
   }
 }

--- a/3_etl_code/ETL_Orchestration/renv.lock
+++ b/3_etl_code/ETL_Orchestration/renv.lock
@@ -11,7 +11,7 @@
   "Python": {
     "Version": "3.10.6",
     "Type": "virtualenv",
-    "Name": "C:/Users/Localadmin_padmanab/Documents/.virtualenvs/etl-test"
+    "Name": "etl-test"
   },
   "Packages": {
     "Achilles": {

--- a/3_etl_code/ETL_Orchestration/sql/etl_achilles_result_concept_count.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_achilles_result_concept_count.sql
@@ -1,0 +1,139 @@
+/************************************************/
+/***** Create record and person count table *****/
+/************************************************/
+DROP TABLE IF EXISTS @schema_achilles.achilles_result_concept_count;
+create table @schema_achilles.achilles_result_concept_count
+(
+  concept_id                INT64,
+  record_count              INT64,
+  descendant_record_count   INT64,
+  person_count              INT64,
+  descendant_person_count   INT64
+);
+/**********************************************/
+/***** Populate record/person count table *****/
+/**********************************************/
+DROP TABLE IF EXISTS @schema_achilles_scratch.tmp_counts;
+CREATE TABLE @schema_achilles_scratch.tmp_counts
+ AS WITH counts as (
+   select stratum_1 as concept_id, max (count_value) as agg_count_value
+   from @schema_achilles.achilles_results
+  where analysis_id in (2, 4, 5, 201, 225, 301, 325, 401, 425, 501, 505, 525, 601, 625, 701, 725, 801, 825,
+    826, 827, 901, 1001, 1201, 1203, 1425, 1801, 1825, 1826, 1827, 2101, 2125, 2301)
+    /* analyses:
+          Number of persons by gender
+         Number of persons by race
+         Number of persons by ethnicity
+         Number of visit occurrence records, by visit_concept_id
+         Number of visit_occurrence records, by visit_source_concept_id
+         Number of providers by specialty concept_id
+         Number of provider records, by specialty_source_concept_id
+         Number of condition occurrence records, by condition_concept_id
+         Number of condition_occurrence records, by condition_source_concept_id
+         Number of records of death, by cause_concept_id
+         Number of death records, by death_type_concept_id
+         Number of death records, by cause_source_concept_id
+         Number of procedure occurrence records, by procedure_concept_id
+         Number of procedure_occurrence records, by procedure_source_concept_id
+         Number of drug exposure records, by drug_concept_id
+         Number of drug_exposure records, by drug_source_concept_id
+         Number of observation occurrence records, by observation_concept_id
+         Number of observation records, by observation_source_concept_id
+         Number of observation records, by value_as_concept_id
+         Number of observation records, by unit_concept_id
+         Number of drug era records, by drug_concept_id
+         Number of condition era records, by condition_concept_id
+         Number of visits by place of service
+         Number of visit_occurrence records, by discharge_to_concept_id
+         Number of payer_plan_period records, by payer_source_concept_id
+         Number of measurement occurrence records, by observation_concept_id
+         Number of measurement records, by measurement_source_concept_id
+         Number of measurement records, by value_as_concept_id
+         Number of measurement records, by unit_concept_id
+         Number of device exposure records, by device_concept_id
+         Number of device_exposure records, by device_source_concept_id
+         Number of location records, by region_concept_id
+    */
+   group by  stratum_1
+  union all
+   select stratum_2 as concept_id, sum (count_value) as agg_count_value
+   from @schema_achilles.achilles_results
+  where analysis_id in (405, 605, 705, 805, 807, 1805, 1807, 2105)
+    /* analyses:
+         Number of condition occurrence records, by condition_concept_id by condition_type_concept_id
+         Number of procedure occurrence records, by procedure_concept_id by procedure_type_concept_id
+         Number of drug exposure records, by drug_concept_id by drug_type_concept_id
+         Number of observation occurrence records, by observation_concept_id by observation_type_concept_id
+         Number of observation occurrence records, by observation_concept_id and unit_concept_id
+         Number of observation occurrence records, by measurement_concept_id by measurement_type_concept_id
+         Number of measurement occurrence records, by measurement_concept_id and unit_concept_id
+         Number of device exposure records, by device_concept_id by device_type_concept_id
+        but this subquery only gets the type or unit concept_ids, i.e., stratum_2
+    */
+   group by  1 )
+ SELECT concept_id,
+  agg_count_value
+ FROM counts;
+DROP TABLE IF EXISTS @schema_achilles_scratch.tmp_counts_person;
+CREATE TABLE @schema_achilles_scratch.tmp_counts_person
+ AS WITH counts_person as (
+   select stratum_1 as concept_id, max (count_value) as agg_count_value
+   from @schema_achilles.achilles_results
+  where analysis_id in (200, 240, 400, 440, 540, 600, 640, 700, 740, 800, 840, 900, 1000, 1300, 1340, 1800, 1840, 2100, 2140, 2200)
+    /* analyses:
+        Number of persons with at least one visit occurrence, by visit_concept_id
+        Number of persons with at least one visit occurrence, by visit_source_concept_id
+        Number of persons with at least one condition occurrence, by condition_concept_id
+        Number of persons with at least one condition occurrence, by condition_source_concept_id
+        Number of persons with death, by cause_source_concept_id
+        Number of persons with at least one procedure occurrence, by procedure_concept_id
+        Number of persons with at least one procedure occurrence, by procedure_source_concept_id
+        Number of persons with at least one drug exposure, by drug_concept_id
+        Number of persons with at least one drug exposure, by drug_source_concept_id
+        Number of persons with at least one observation occurrence, by observation_concept_id
+        Number of persons with at least one observation occurrence, by observation_source_concept_id
+        Number of persons with at least one drug era, by drug_concept_id
+        Number of persons with at least one condition era, by condition_concept_id
+        Number of persons with at least one visit detail, by visit_detail_concept_id
+        Number of persons with at least one visit detail, by visit_detail_source_concept_id
+        Number of persons with at least one measurement occurrence, by measurement_concept_id
+        Number of persons with at least one measurement occurrence, by measurement_source_concept_id
+        Number of persons with at least one device exposure, by device_concept_id
+        Number of persons with at least one device exposure, by device_source_concept_id
+        Number of persons with at least one note by  note_type_concept_id
+    */
+   group by  1 )
+ SELECT concept_id,
+  agg_count_value
+ FROM counts_person;
+DROP TABLE IF EXISTS @schema_achilles_scratch.tmp_concepts;
+CREATE TABLE @schema_achilles_scratch.tmp_concepts
+ AS WITH concepts as (
+  select concept_id as ancestor_id, coalesce(cast(ca.descendant_concept_id as STRING), concept_id) as descendant_id
+  from (
+    select concept_id from @schema_achilles_scratch.tmp_counts
+    union distinct select distinct cast(ancestor_concept_id as STRING) concept_id
+    from @schema_achilles_scratch.tmp_counts c
+    join @schema_vocab.concept_ancestor ca on cast(ca.descendant_concept_id as STRING) = c.concept_id
+  ) c
+  left join @schema_vocab.concept_ancestor ca on c.concept_id = cast(ca.ancestor_concept_id as STRING)
+)
+ SELECT ancestor_id,
+  descendant_id
+ FROM concepts;
+insert into @schema_achilles.achilles_result_concept_count (concept_id, record_count, descendant_record_count, person_count, descendant_person_count)
+ select distinct
+    cast(concepts.ancestor_id  as int64) as concept_id,
+    coalesce(cast(max(c1.agg_count_value) as int64), 0) as record_count,
+    coalesce(cast(sum(c2.agg_count_value) as int64), 0) as descendant_record_count,
+    coalesce(cast(max(c3.agg_count_value) as int64), 0) as person_count,
+    coalesce(cast(sum(c4.agg_count_value) as int64), 0) as descendant_person_count
+ from @schema_achilles_scratch.tmp_concepts concepts
+         left join @schema_achilles_scratch.tmp_counts c1 on concepts.ancestor_id = c1.concept_id
+         left join @schema_achilles_scratch.tmp_counts c2 on concepts.descendant_id = c2.concept_id
+         left join @schema_achilles_scratch.tmp_counts_person c3 on concepts.ancestor_id = c3.concept_id
+         left join @schema_achilles_scratch.tmp_counts_person c4 on concepts.descendant_id = c4.concept_id
+ group by  concepts.ancestor_id ;
+DROP TABLE IF EXISTS @schema_achilles_scratch.tmp_counts;
+DROP TABLE IF EXISTS @schema_achilles_scratch.tmp_counts_person;
+DROP TABLE IF EXISTS @schema_achilles_scratch.tmp_concepts;


### PR DESCRIPTION
This is for issue #126 

Things corrected

- Achilles updated to the commit that adds the [person count for non-standard codes into analysis](https://github.com/OHDSI/Achilles/pull/721/commits)
- Added the SQL script to calculate Achilles result concept count table
- Modified the `run_config_template` to add this etl step
- Modified the `run_ETL_in_atlasdev.R` to properly run the ETL followed by Achilles and then achilles_result_concept_count