### PR TITLE
Properly working concept ancestry

### DIFF
--- a/3_etl_code/ETL_Orchestration/R/setup_enviroment_functions.R
+++ b/3_etl_code/ETL_Orchestration/R/setup_enviroment_functions.R
@@ -48,6 +48,23 @@ create_tables_and_load_vocabulary <- function(config) {
   # call
   py_load_vocabulary(path_to_gcp_key, path_to_vocabulary_zip, tmp_folder, schema_vocab)
 
+  # Add non-standard concept ancestry information to concept_ancestor table -----------------------------------------------------
+  ## read connection details from yaml
+  connectionDetails <- rlang::exec(DatabaseConnector::createConnectionDetails, !!!config$connection)
+  conn <- DatabaseConnector::connect(connectionDetails)
+
+  # Create  cdm  vocab tables
+  sql <- SqlRender::readSql("sql/setup_add_concept_ancestry.sql")
+  sql <- SqlRender::render(
+    sql,
+    schema_vocab = config$schema_vocab
+  )
+
+  DatabaseConnector::executeSql(conn, paste(sql, collapse = "\n"))
+
+  # Close connection
+  DatabaseConnector::disconnect(conn)
+
 }
 
 

--- a/3_etl_code/ETL_Orchestration/sql/setup_add_concept_ancestry.sql
+++ b/3_etl_code/ETL_Orchestration/sql/setup_add_concept_ancestry.sql
@@ -1,0 +1,52 @@
+# DESCRIPTION:
+# Adds non-standard FinOMOP and ICD10 vocabularies concept ancestry to the concetp_ancestor table
+#
+# PARAMETERS:
+#
+# - schema_vocab: path to schema_vocab
+
+BEGIN
+# 1-  Create a temporary bigquery table with concept relationships that have
+# 1-1 Any concept > 2 billion or from ICD10 vocabulary
+# 1-2 Only get that have relationship `Subsumes` present
+CREATE OR REPLACE TABLE sandbox.relationships AS
+SELECT concept_id AS concept_id_1, relationship_id, concept_id_2
+FROM @schema_vocab.concept
+LEFT JOIN @schema_vocab.concept_relationship
+ON concept_id_1 = concept_id AND relationship_id = 'Subsumes'
+WHERE (concept_id > 2000000000 OR vocabulary_id = 'ICD10') AND vocabulary_id NOT IN ('Vocabulary','Concept Class') AND relationship_id IS NOT NULL
+ORDER BY concept_id, concept_id_2;
+
+# 2- Insert the created non-standard concept ancestries to concept_ancestor table in omop vocab
+INSERT INTO @schema_vocab.concept_ancestor
+(
+	ancestor_concept_id,
+	descendant_concept_id,
+	min_levels_of_separation,
+	max_levels_of_separation
+)
+# 3- Create a min and max distance as 1 for every concept relation
+# 3-1 Recursively check descendant_concept_id untill there are no descendants
+WITH RECURSIVE ancestor_cte AS (
+# Base case: direct relationships
+	SELECT concept_id_1 AS ancestor_concept_id,
+			concept_id_2 AS descendant_concept_id,
+			1 AS min_levels_of_separation,
+			1 AS max_levels_of_separation
+	FROM sandbox.relationships
+	UNION ALL
+# Recursive case: find descandant relationships
+	SELECT r.concept_id_1 AS ancestor_concept_id,
+			c.descendant_concept_id AS descendant_concept_id,
+			c.min_levels_of_separation + 1 AS min_levels_of_separation,
+			c.max_levels_of_separation + 1 AS max_levels_of_separation
+	FROM sandbox.relationships r
+	JOIN ancestor_cte c
+	ON r.concept_id_2 = c.ancestor_concept_id
+)
+SELECT *
+FROM ancestor_cte;
+
+# 4- Remove the temporary table
+DROP TABLE IF EXISTS sandbox.relationships;
+END;


### PR DESCRIPTION
This is for issue #172 

Concept ancestor table now contains non-standard codes concept ancestry information constructed based on `concept_relationship` table. 

- [x] Checked out some non-standard codes `J45` ancestry codes and it is correctly captured. 
- [x] Checked `ICD10fi`, `ICD10` vocabulary codes and looked correct.
- [x] Atlas to verify the concept ancestry

Atlas properly recognizes the descendants for Asthma `J45` code
![image](https://github.com/user-attachments/assets/f98480ce-6f17-4d73-8bce-1b655e80e62a)

Here is all the codes captured
![image](https://github.com/user-attachments/assets/0d95b7d6-b770-4de0-ac2a-01994d0c507b)
 