### PR TITLE
Fixed HLA imputed SQL and works as intended.

### DIFF
--- a/2_etl_specifications/documentation/hla.md
+++ b/2_etl_specifications/documentation/hla.md
@@ -1,0 +1,10 @@
+---
+title: HLA
+layout: default
+nav_order: 13
+has_children: true
+---
+
+## HLA 
+
+HLA values registry contains imputed HLA alleles of genes for FINNGENIDs within FinnGen [[FinnGen Handbook](https://docs.finngen.fi/finngen-data-specifics/green-library-data-aggregate-data/other-analyses-available/hla)]

--- a/2_etl_specifications/documentation/hla_to_measurement.md
+++ b/2_etl_specifications/documentation/hla_to_measurement.md
@@ -1,0 +1,61 @@
+---
+title: hla to measurement
+layout: default
+parent: HLA
+nav_order: 1
+---
+
+## hla to measurement
+
+```mermaid
+%%{init: {'theme': 'base' } }%%
+%%{init: {'theme': 'base' } }%%
+flowchart LR
+    subgraph Source
+        finngenid
+        Allele
+        HALcode
+    end
+
+    subgraph CDM-OMOP-v5.4
+        person_id
+        measurement_source_concept_id
+        measurement_source_value
+    end
+
+    finngenid-->person_id
+    
+    HALcode-->measurement_source_concept_id
+    Allele-->measurement_source_value
+    HALcode-->measurement_source_value
+
+```
+
+| Destination Field | Source field | Logic | Comment field |
+| --- | --- | --- | --- |
+| measurement_id |  | Incremental integer. Unique value per each row measurement + 119000000000 (offset) | Generated |
+| person_id | finngenid | `person_id` from person table where `person_source_value` equals `finngenid` |   Calculated |
+| measurement_concept_id |  | Set 0 for all | Info not available |
+| measurement_date |  | Set `2025-12-18` for all | Calculated |
+| measurement_datetime |  | Copied from  `measurement_date` | Copied |
+| measurement_time |  | extract time from `measurement_datetime` for all | Calculated |
+| measurement_type_concept_id |  | Set 32879 - 'Registry' for all | Calculated |
+| operator_concept_id |  | Set 0 for all | Info not available |
+| value_as_number |  | Set NULL for all  | Info not available |
+| value_as_concept_id |  | Set 0 for all | Info not available |
+| unit_concept_id |  | Set 0 for all  | Info not available |
+| range_low |  | Set NULL for all | Info not available |
+| range_high |  | Set NULL for all | Info not available |
+| provider_id |  | Set NULL for all | Info not available |
+| visit_occurrence_id |  | Set NULL for all | No Visit logged |
+| visit_detail_id |  | Set NULL for all | Info not available |
+| measurement_source_value | HLAcode<br>Allele | Concat `HLAcode` and `Allele` | Calculated |
+| measurement_source_concept_id | HLAcode | `omop_concept_id` from concept table where `concept_code` equals `HLAcode` | Calculated |
+| unit_source_value |  | Set NULL for all | Info not available |
+| unit_source_concept_id |  | Set 0 for all | Info not available |
+| value_source_value |  | Set NULL for all | Info not available |
+| measurement_event_id |  | Set NULL for all | Info not available |
+| meas_event_field_concept_id |  | Set 0 for all | Info not available |
+
+
+

--- a/2_etl_specifications/documentation/home.md
+++ b/2_etl_specifications/documentation/home.md
@@ -32,6 +32,7 @@ flowchart LR
         vision[<a href='vision.html'>vision</a>]
         kidney[<a href='kidney.html'>kidney</a>]
         kanta[<a href='kanta.html'>kanta</a>]
+        hla[<a href='hla.html'>hla</a>]
     end
 
     stem[<a href='stem.html'>stem</a>]
@@ -89,6 +90,8 @@ flowchart LR
     kanta --> visit_occurrence
     kanta --> measurement
     kanta --> provider
+
+    hla --> measurement
     
     stem --> conndition_occurrence 
     stem --> procedure_occurrence
@@ -180,6 +183,10 @@ Kanta [[FinnGen Handbook](https://finngen.gitbook.io/finngen-handbook/finngen-da
 - [kanta to visit_occurence](kanta_to_visit_occurrence.html)
 - [kanta to measurement](kanta_to_measurement.html)
 
+## HLA
+HLA [[FinnGen Handbook](https://docs.finngen.fi/finngen-data-specifics/green-library-data-aggregate-data/other-analyses-available/hla)].
+
+- [hla to measurement](hla_to_measurement.html)
 
 ## stem
 

--- a/3_etl_code/ETL_Orchestration/R/etl_functions.R
+++ b/3_etl_code/ETL_Orchestration/R/etl_functions.R
@@ -33,6 +33,7 @@ run_etl_steps <- function(logger, config, run_config) {
       schema_table_vision = config$schema_table_vision,
       schema_table_kanta = config$schema_table_kanta,
       schema_drug_events = config$schema_drug_events,
+      schema_hla_imputed = config$schema_hla_imputed,
       schema_table_codes_info = config$schema_table_codes_info,
       schema_table_finngen_vnr = config$schema_table_finngen_vnr,
       schema_vocab = config$schema_vocab,

--- a/3_etl_code/ETL_Orchestration/sql/etl_hla_imputed_to_measurement.sql
+++ b/3_etl_code/ETL_Orchestration/sql/etl_hla_imputed_to_measurement.sql
@@ -1,0 +1,104 @@
+# DESCRIPTION:
+# Creates a row in cdm.measurement table for each hla imputed code in the source.hla_imputed.
+# Currently no mapping is done. Only the source codes are used.
+# Insert resulting events into the cdm.measurement table.
+# measurement_id is added by an offset of 119000000000
+#
+#
+# PARAMETERS:
+#
+# - schema_etl_input: schema with the etl input tables
+# - schema_cdm_output: schema with the output CDM tables
+
+INSERT INTO @schema_cdm_output.measurement
+(
+    measurement_id,
+    person_id,
+    measurement_concept_id,
+    measurement_date,
+    measurement_datetime,
+    measurement_time,
+    measurement_type_concept_id,
+    operator_concept_id,
+    value_as_number,
+    value_as_concept_id,
+    unit_concept_id,
+    range_low,
+    range_high,
+    provider_id,
+    visit_occurrence_id,
+    visit_detail_id,
+    measurement_source_value,
+    measurement_source_concept_id,
+    unit_source_value,
+    unit_source_concept_id,
+    value_source_value,
+    measurement_event_id,
+    meas_event_field_concept_id
+)
+
+WITH hla_imputed AS (
+  SELECT FINNGENID, Allele, HLAcode
+  FROM @schema_hla_imputed
+),
+hla_imputed_source_code AS (
+  SELECT hi.FINNGENID,
+         hi.Allele,
+         hi.HLAcode,
+         c.concept_id AS omop_concept_id
+  FROM hla_imputed AS hi
+  LEFT JOIN @schema_vocab.concept AS c
+  ON c.concept_code = hi.HLAcode
+)
+# 5 - Shape into measurement table
+SELECT
+# measurement_id
+  ROW_NUMBER() OVER(ORDER by hisc.FINNGENID) + 119000000000 AS measurement_id,
+# person_id
+  p.person_id AS person_id,
+# measurement_concept_id
+  0 AS measurement_concept_id,
+# measurement_date
+  CAST('2025-12-18' AS DATE) AS measurement_date,
+# measurement_datetime
+  DATETIME(TIMESTAMP(CAST('2025-12-18' AS DATE))) AS measurement_datetime,
+# measurement_time
+  CAST(EXTRACT(TIME FROM DATETIME(TIMESTAMP(CAST('2025-12-18' AS DATE)))) AS STRING) AS measurement_time,
+# measurement_type_concept_id
+  32879 AS measurement_type_concept_id,
+# operator_concept_id
+  0 AS operator_concept_id,
+# value_as_number - Negative values will only be accepted if the concept_id is from OHDSI prescribed standard concepts
+  NULL AS value_as_number,
+# value_as_concept_id
+  0 AS value_as_concept_id,
+# unit_concept_id
+  0 AS unit_concept_id,
+# range_low
+  NULL AS range_low,
+# range_high
+  NULL AS range_high,
+# provider_id
+  NULL AS provider_id,
+# visit_occurrence_id
+  NULL AS visit_occurrence_id,
+# visit_detail_id
+  NULL AS visit_detail_id,
+# measurement_source_value
+   CONCAT(hisc.HLAcode,' with allele ',hisc.Allele) AS measurement_source_value,
+# measurement_source_concept_id
+  hisc.omop_concept_id AS measurement_source_concept_id,
+# unit_source_value
+  CAST(NULL AS STRING) AS unit_source_value,
+# unit_source_concept_id
+  0 AS unit_source_concept_id,
+# value_source_value
+  CAST(NULL AS STRING) AS value_source_value,
+# measurement_event_id
+  NULL AS measurement_event_id,
+# meas_event_field_concept_id
+  0 AS meas_event_field_concept_id
+FROM hla_imputed_source_code AS hisc
+JOIN @schema_cdm_output.person AS p
+ON p.person_source_value = hisc.FINNGENID
+ORDER BY person_id, measurement_id;

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# ETL vDF13.4
+
+- ETL for FinnGen DF13 v4
+- Registers: Service-sector-data, birth mother, vision, kidney and Kanta drug registries
+- Kanta lab values now use `measurement_unit_harmonized`
+- Drug exposure table will not include `PRESCRIPTION` only drug events
+- Added HLA imputed data as non-standard concepts without any standard mapping and exist only in measurement table
+
 # ETL vDF13.3
 
 - ETL for FinnGen DF13 v3


### PR DESCRIPTION
This is for issue #235 

The SQL returns 0 standard concepts and does not bother with visits. 

It uses temporary measurement date as it is one of the required columns. We can make it dynamic like setting it to current date or just random date. 

measurement_source_concept_is is captured directly using concept table.
measurement_source_value also includes allele. 
Ex: 
| FINNGENID | Allele | HLAcode |
| ---- | ---- | ---- |
| FG00000001 | 1 | A*:06:01|

This will have `measurement_source_value` as `A*:06:01 with allele 1`